### PR TITLE
CI stability via NuGet cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,18 @@ jobs:
       with:
         dotnet-version: 8.0.x
 
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+
+    - name: Set build environment
+      run: echo "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" >> $GITHUB_ENV
+        && echo "NUGET_PACKAGES=$HOME/.nuget/packages" >> $GITHUB_ENV
+
     - name: Restore dependencies
       run: dotnet restore
 

--- a/docs/changes/20250729_progress.md
+++ b/docs/changes/20250729_progress.md
@@ -1,0 +1,7 @@
+## 2025-07-29 09:00 JST [kusunoki]
+- CI の dotnet restore 失敗を調査。NuGet パッケージ取得が不安定だったためキャッシュ導入を検討
+- actions/cache による ~/.nuget/packages 保存と DOTNET_SKIP_FIRST_TIME_EXPERIENCE 設定を検証
+
+## 2025-07-29 10:00 JST [shion]
+- ci.yml に NuGet キャッシュステップを追加し、環境変数で初回セットアップを無効化
+- ローカルで `dotnet restore` `dotnet test` を実行し再現しないことを確認

--- a/docs/diff_log/diff_ci_nuget_stabilization_20250729.md
+++ b/docs/diff_log/diff_ci_nuget_stabilization_20250729.md
@@ -1,0 +1,18 @@
+# 差分履歴: ci_nuget_stabilization
+
+🗕 2025-07-29 (JST)
+🧐 作業者: 詩音
+
+## 差分タイトル
+CI の NuGet キャッシュ追加によるビルド安定化
+
+## 変更理由
+- CI で `dotnet restore` が 503 エラーを返すことがあり、復旧に時間がかかっていた
+- NuGet フィードへのネットワーク不安定性を緩和するためキャッシュポリシーを導入
+
+## 追加・修正内容（反映先: oss_design_combined.md）
+- `.github/workflows/ci.yml` に `actions/cache` を追加し `~/.nuget/packages` を保存
+- `DOTNET_SKIP_FIRST_TIME_EXPERIENCE` と `NUGET_PACKAGES` を環境変数として設定
+
+## 参考文書
+- docs/troubleshooting.md セクション "CI エラー対策"


### PR DESCRIPTION
## Summary
- stabilize the build by caching NuGet packages
- document the CI fix in progress logs
- record changes in diff log

## Testing
- `dotnet restore`
- `dotnet test --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_6872ee2ebb0c83278498a76665ba7cae