### PR TITLE
Enhance MappingManager docs and tests

### DIFF
--- a/docs/architecture/key_value_flow.md
+++ b/docs/architecture/key_value_flow.md
@@ -121,6 +121,6 @@ await ctx.AddAsync(entity);
 
 ### 異常系の流れ
 
-1. `MappingManager` に登録されていないエンティティを渡した場合、`KeyNotFoundException` が発生する。
+1. `MappingManager` に登録されていないエンティティを渡した場合、`InvalidOperationException` が発生する。
 2. `KsqlContext` との接続に失敗した場合は `KafkaException` を上位へ伝搬する。
 

--- a/docs/changes/20250728_progress.md
+++ b/docs/changes/20250728_progress.md
@@ -5,3 +5,7 @@
 - FullAutoQueryFlowTests compile fix using IQueryable expression
 - Sample updated accordingly
 
+
+## 2025-07-28 11:30 JST [shion]
+- MappingManager API test cases expanded to cover unregistered entities, composite keys, and type conversion checks
+- Documentation updated with exception behavior

--- a/features/mapping_manager/viewpoints.md
+++ b/features/mapping_manager/viewpoints.md
@@ -25,6 +25,7 @@
 2. **複合キーが登録されている場合、`Dictionary<string, object>` としてキーが返る**
 3. **`Register` を複数回呼び出すと後の登録で上書きされる**
 4. **キーが登録されていない場合でも `KeyExtractor` が `Guid` を生成し正常に返る**
+5. **`int` `long` `string` `Guid` 各型のキー値が `KeyToString` で正しく文字列化される**
 
 ### 異常系
 1. **未登録のエンティティを渡すと `InvalidOperationException` が発生する**
@@ -38,6 +39,7 @@
 - 複合キーはプロパティ名→値の辞書に変換し、`null` は空文字列へ変換される。
 - `KeyToString` で `Dictionary` 型を "`key=value`" 形式で連結している。
 - `IsSupportedKeyType` では `Nullable<T>` の実体型を評価する。
+- 複合キー辞書のプロパティ順序がモデル定義順で保持されるか確認する。
 
 ## 4. 現状仕様で不足する論点
 - モデル再登録のロック機構がなく、マルチスレッド環境で競合する可能性。

--- a/tests/Core/KeyExtractorTests.cs
+++ b/tests/Core/KeyExtractorTests.cs
@@ -1,6 +1,7 @@
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Models;
 using Kafka.Ksql.Linq.Serialization.Abstractions;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Xunit;

--- a/tests/Core/KeyExtractorTests.cs
+++ b/tests/Core/KeyExtractorTests.cs
@@ -101,9 +101,18 @@ public class KeyExtractorTests
     }
 
     [Fact]
+    public void KeyToString_WithGuid_ReturnsGuidString()
+    {
+        var g = Guid.NewGuid();
+        var result = KeyExtractor.KeyToString(g);
+        Assert.Equal(g.ToString(), result);
+    }
+
+    [Fact]
     public void IsSupportedKeyType_ReturnsExpectedResults()
     {
         Assert.True(KeyExtractor.IsSupportedKeyType(typeof(int)));
+        Assert.True(KeyExtractor.IsSupportedKeyType(typeof(Guid?)));
         Assert.False(KeyExtractor.IsSupportedKeyType(typeof(decimal)));
         Assert.False(KeyExtractor.IsSupportedKeyType(typeof(byte[])));
     }

--- a/tests/Mapping/MappingManagerTests.cs
+++ b/tests/Mapping/MappingManagerTests.cs
@@ -1,5 +1,7 @@
 using Kafka.Ksql.Linq.Core.Modeling;
 using Kafka.Ksql.Linq.Mapping;
+using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Kafka.Ksql.Linq.Tests.Mapping;
@@ -10,6 +12,12 @@ public class MappingManagerTests
     {
         public int Id { get; set; }
         public string Name { get; set; } = string.Empty;
+    }
+
+    private class CompositeSample
+    {
+        public int Id { get; set; }
+        public string Code { get; set; } = string.Empty;
     }
 
     [Fact]
@@ -29,5 +37,61 @@ public class MappingManagerTests
 
         Assert.Equal(1, result.Key);
         Assert.Same(entity, result.Value);
+    }
+
+    [Fact]
+    public void ExtractKeyValue_UnregisteredEntity_Throws()
+    {
+        var manager = new MappingManager();
+        var entity = new Sample { Id = 1 };
+
+        Assert.Throws<InvalidOperationException>(() => manager.ExtractKeyValue(entity));
+    }
+
+    [Fact]
+    public void ExtractKeyValue_NullEntity_Throws()
+    {
+        var manager = new MappingManager();
+
+        Assert.Throws<ArgumentNullException>(() => manager.ExtractKeyValue<Sample>(null!));
+    }
+
+    [Fact]
+    public void ExtractKeyValue_WithCompositeKey_ReturnsDictionary()
+    {
+        var builder = new ModelBuilder();
+        builder.Entity<CompositeSample>()
+            .WithTopic("composite-topic")
+            .HasKey(e => new { e.Id, e.Code });
+        var model = builder.GetEntityModel<CompositeSample>()!;
+
+        var manager = new MappingManager();
+        manager.Register<CompositeSample>(model);
+
+        var entity = new CompositeSample { Id = 7, Code = "x" };
+        var result = manager.ExtractKeyValue(entity);
+        var dict = Assert.IsType<Dictionary<string, object>>(result.Key);
+        Assert.Equal(7, dict[nameof(CompositeSample.Id)]);
+        Assert.Equal("x", dict[nameof(CompositeSample.Code)]);
+    }
+
+    [Fact]
+    public void Register_SameEntityTwice_OverridesModel()
+    {
+        var b1 = new ModelBuilder();
+        b1.Entity<Sample>().WithTopic("t1").HasKey(e => e.Id);
+        var m1 = b1.GetEntityModel<Sample>()!;
+
+        var b2 = new ModelBuilder();
+        b2.Entity<Sample>().WithTopic("t2").HasKey(e => e.Name);
+        var m2 = b2.GetEntityModel<Sample>()!;
+
+        var manager = new MappingManager();
+        manager.Register<Sample>(m1);
+        manager.Register<Sample>(m2);
+
+        var entity = new Sample { Id = 1, Name = "B" };
+        var result = manager.ExtractKeyValue(entity);
+        Assert.Equal("B", result.Key);
     }
 }


### PR DESCRIPTION
## Summary
- clarify exception from MappingManager for unregistered models
- note key type stringification expectations
- add progress entry for MappingManager API work
- extend MappingManager unit tests for edge cases
- improve KeyExtractor tests for Guid handling

## Testing
- `dotnet test Kafka.Ksql.Linq.sln --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6872ee5eb5cc832793d6df432bf006e2