### PR TITLE
Enhance MappingManager with new sample

### DIFF
--- a/examples/naruse/mapping_manager/MappingManagerSample.csproj
+++ b/examples/naruse/mapping_manager/MappingManagerSample.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../src/Kafka.Ksql.Linq.csproj" />
+  </ItemGroup>
+</Project>

--- a/examples/naruse/mapping_manager/Program.cs
+++ b/examples/naruse/mapping_manager/Program.cs
@@ -1,0 +1,41 @@
+using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Entities.Samples;
+using Kafka.Ksql.Linq.Entities.Samples.Models;
+using Kafka.Ksql.Linq.Mapping;
+using Kafka.Ksql.Linq.Query.Analysis;
+using Microsoft.Extensions.DependencyInjection;
+using System.Linq;
+using System.Threading.Tasks;
+
+public class SampleContext : KsqlContext
+{
+    protected override void OnModelCreating(IModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Order>()
+            .WithTopic("orders")
+            .HasKey(o => new { o.OrderId, o.UserId });
+    }
+}
+
+class Program
+{
+    static async Task Main()
+    {
+        var services = new ServiceCollection();
+        services.AddSampleModels();              // MappingManager registration
+        services.AddSingleton<IMappingManager, MappingManager>();
+        services.AddSingleton<SampleContext>();
+        var provider = services.BuildServiceProvider();
+        var ctx = provider.GetRequiredService<SampleContext>();
+        var mapping = provider.GetRequiredService<IMappingManager>();
+
+        // build schema from LINQ query
+        var result = QueryAnalyzer.AnalyzeQuery<Order, Order>(src => src.Where(o => o.Quantity > 1));
+        var schema = result.Schema!;
+
+        var order = new Order { OrderId = 1, UserId = 10, ProductId = 5, Quantity = 2 };
+        var (key, value) = mapping.ExtractKeyValue(order);
+        await ctx.Set<Order>().AddAsync(order);
+    }
+}

--- a/examples/naruse/mapping_manager/README.md
+++ b/examples/naruse/mapping_manager/README.md
@@ -1,0 +1,10 @@
+# MappingManager AddAsync Sample
+
+This sample demonstrates the standardized `AddAsync` flow using `MappingManager`.
+A simple `Order` entity is registered via `AddSampleModels`, converted to
+key/value pairs, and sent through `KsqlContext.AddAsync`.
+
+Run with:
+```bash
+dotnet run --project .
+```

--- a/src/Mapping/MappingManager.cs
+++ b/src/Mapping/MappingManager.cs
@@ -4,6 +4,7 @@ using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Models;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 public class MappingManager : IMappingManager
 {
@@ -17,11 +18,26 @@ public class MappingManager : IMappingManager
 
     public (object Key, TEntity Value) ExtractKeyValue<TEntity>(TEntity entity) where TEntity : class
     {
-        if (entity == null) throw new ArgumentNullException(nameof(entity));
+        if (entity == null)
+            throw new ArgumentNullException(nameof(entity));
+
         if (!_models.TryGetValue(typeof(TEntity), out var model))
             throw new InvalidOperationException($"Model for {typeof(TEntity).Name} is not registered.");
 
-        var key = KeyExtractor.ExtractKeyValue(entity, model);
-        return (key, entity);
+        try
+        {
+            var key = KeyExtractor.ExtractKeyValue(entity, model);
+
+            if (key != null && key is not Dictionary<string, object> && !KeyExtractor.IsSupportedKeyType(key.GetType()))
+            {
+                throw new NotSupportedException($"Key type {key.GetType().Name} is not supported.");
+            }
+
+            return (key!, entity);
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidCastException or FormatException)
+        {
+            throw new InvalidOperationException($"Failed to extract key for {typeof(TEntity).Name}: {ex.Message}", ex);
+        }
     }
 }

--- a/tests/Mapping/AddAsyncSampleFlowTests.cs
+++ b/tests/Mapping/AddAsyncSampleFlowTests.cs
@@ -1,0 +1,83 @@
+using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Mapping;
+using Kafka.Ksql.Linq.Messaging.Abstractions;
+using Kafka.Ksql.Linq.Messaging.Producers.Core;
+using Kafka.Ksql.Linq.Configuration;
+using Kafka.Ksql.Linq.Entities.Samples.Models;
+using SampleOrder = Kafka.Ksql.Linq.Entities.Samples.Models.Order;
+using Kafka.Ksql.Linq.Entities.Samples;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Mapping;
+
+public class AddAsyncSampleFlowTests
+{
+    private class StubProducer<T> : IKafkaProducer<T> where T : class
+    {
+        public bool Sent;
+        public string TopicName => "orders";
+        public Task<KafkaDeliveryResult> SendAsync(T message, KafkaMessageContext? context = null, CancellationToken cancellationToken = default)
+        {
+            Sent = true;
+            return Task.FromResult(new KafkaDeliveryResult());
+        }
+        public Task<KafkaBatchDeliveryResult> SendBatchAsync(IEnumerable<T> messages, KafkaMessageContext? context = null, CancellationToken cancellationToken = default)
+        {
+            Sent = true;
+            return Task.FromResult(new KafkaBatchDeliveryResult());
+        }
+        public Task FlushAsync(System.TimeSpan timeout) => Task.CompletedTask;
+        public void Dispose() { }
+    }
+
+    private class TestContext : KsqlContext
+    {
+        public TestContext() : base() { }
+        protected override bool SkipSchemaRegistration => true;
+        public void SetProducerManager(KafkaProducerManager manager)
+        {
+            typeof(KsqlContext).GetField("_producerManager", BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(this, manager);
+        }
+        protected override void OnModelCreating(IModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<SampleOrder>()
+                .WithTopic("orders")
+                .HasKey(o => new { o.OrderId, o.UserId });
+        }
+    }
+
+    [Fact]
+    public async Task AddAsync_Flow_SendsMessage()
+    {
+        var services = new ServiceCollection();
+        services.AddSampleModels();
+        services.AddSingleton<TestContext>();
+        var provider = services.BuildServiceProvider();
+        var ctx = provider.GetRequiredService<TestContext>();
+        var mapping = provider.GetRequiredService<IMappingManager>();
+
+        var manager = new KafkaProducerManager(Options.Create(new KsqlDslOptions()), null);
+        ctx.SetProducerManager(manager);
+        var stub = new StubProducer<SampleOrder>();
+        var dict = (ConcurrentDictionary<System.Type, object>)typeof(KafkaProducerManager)
+            .GetField("_producers", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(manager)!;
+        dict[typeof(SampleOrder)] = stub;
+
+        var order = new SampleOrder { OrderId = 1, UserId = 10, ProductId = 5, Quantity = 2 };
+        var (key, value) = mapping.ExtractKeyValue(order);
+        Assert.IsType<Dictionary<string, object>>(key);
+
+        await ctx.Set<SampleOrder>().AddAsync(order);
+
+        Assert.True(stub.Sent);
+    }
+}


### PR DESCRIPTION
## Summary
- improve MappingManager error handling and key validation
- add AddAsync standardization sample under examples/naruse/mapping_manager
- extend MappingManager unit tests
- add integration-style AddAsync test

## Testing
- `dotnet test Kafka.Ksql.Linq.sln -v minimal` *(fails: SelectExpressionVisitorDtoOrderTests.VisitNew_GroupKeyOrderMatch_NoException)*

------
https://chatgpt.com/codex/tasks/task_e_68731f071ecc8327a4f28d089df36245