### PR TITLE
Implement tuple-based composite key extraction

### DIFF
--- a/docs/architecture/key_value_flow.md
+++ b/docs/architecture/key_value_flow.md
@@ -104,9 +104,12 @@ var mapping = ctx.MappingManager;
 
 var ksql = builder.Build(query);
 var entity = new User { Id = 1, Name = "Alice" };
-var (key, value) = mapping.ExtractKeyValue(entity);
+var parts = mapping.ExtractKeyParts(entity);
+var key = KeyExtractor.BuildTypedKey(parts);
 await ctx.AddAsync(entity);
 ```
+
+複合キーは `List<(string KeyName, Type KeyType, string Value)>` として抽出し、送信時に `BuildTypedKey` で型変換する方式へ移行しました。既存の `ExtractKeyValue` は互換APIとして残ります。
 
 ### ベストプラクティス
 

--- a/docs/architecture/query_to_addasync_sample.md
+++ b/docs/architecture/query_to_addasync_sample.md
@@ -22,8 +22,11 @@ var schema = result.Schema!;
 
 // key/value 抽出と送信
 var order = new Order { OrderId = 1, UserId = 10, ProductId = 5, Quantity = 2 };
-var (key, value) = mapping.ExtractKeyValue(order);
+var parts = mapping.ExtractKeyParts(order);
+var key = KeyExtractor.BuildTypedKey(parts);
 await ctx.Set<Order>().AddAsync(order);
 ```
+
+`ExtractKeyParts` で取得した複合キーは Type 情報を保持するため、安全に `BuildTypedKey` で変換できます。
 
 この流れにより、クエリ定義からメッセージ送信までを DI コンテナ上のサービスで完結させることができます。

--- a/docs/changes/20250713_progress.md
+++ b/docs/changes/20250713_progress.md
@@ -16,3 +16,8 @@
 ## 2025-07-13 11:56 JST [shunto]
 - FullAutoQueryFlowTests に QuerySchemaHelper 検証を追加
 - `dotnet test` 実行し 588 件成功を確認
+
+## 2025-07-13 13:00 JST [assistant]
+- 複合キーを `(key名, 型, 値)` Tuple で保持する新方式を実装
+- MappingManager・KafkaProducer を更新し型変換エラーログを追加
+- docs とユニットテストを更新

--- a/docs/diff_log/diff_composite_key_tuple_20250713.md
+++ b/docs/diff_log/diff_composite_key_tuple_20250713.md
@@ -1,0 +1,18 @@
+# 差分履歴: composite_key_tuple_conversion
+
+🗕 2025年7月13日（JST）
+🧐 作業者: assistant
+
+## 差分タイトル
+複合キー抽出のTuple方式導入
+
+## 変更理由
+Dictionary形式では型情報が失われるため、送信時の安全な型変換を保証する目的。
+
+## 追加・修正内容（反映先: oss_design_combined.md）
+- `KeyExtractor` に `ExtractKeyParts` と `BuildTypedKey` を追加
+- `MappingManager` と `KafkaProducer` を新方式で実装
+- ドキュメントサンプルを新APIに更新
+
+## 参考文書
+- `docs/architecture/key_value_flow.md`

--- a/src/Core/Models/CompositeKeyPart.cs
+++ b/src/Core/Models/CompositeKeyPart.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Kafka.Ksql.Linq.Core.Models;
+
+public readonly struct CompositeKeyPart
+{
+    public string KeyName { get; }
+    public Type KeyType { get; }
+    public string Value { get; }
+
+    public CompositeKeyPart(string keyName, Type keyType, string value)
+    {
+        KeyName = keyName;
+        KeyType = keyType;
+        Value = value;
+    }
+}

--- a/src/Mapping/IMappingManager.cs
+++ b/src/Mapping/IMappingManager.cs
@@ -1,6 +1,8 @@
 namespace Kafka.Ksql.Linq.Mapping;
 
 using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Models;
+using System.Collections.Generic;
 
 public interface IMappingManager
 {
@@ -13,4 +15,9 @@ public interface IMappingManager
     /// Extracts key/value pair from the entity according to its model.
     /// </summary>
     (object Key, TEntity Value) ExtractKeyValue<TEntity>(TEntity entity) where TEntity : class;
+
+    /// <summary>
+    /// Extracts composite key parts from the entity (new recommended API).
+    /// </summary>
+    List<CompositeKeyPart> ExtractKeyParts<TEntity>(TEntity entity) where TEntity : class;
 }

--- a/src/Mapping/MappingManager.cs
+++ b/src/Mapping/MappingManager.cs
@@ -16,6 +16,17 @@ public class MappingManager : IMappingManager
         _models[typeof(TEntity)] = model;
     }
 
+    public List<CompositeKeyPart> ExtractKeyParts<TEntity>(TEntity entity) where TEntity : class
+    {
+        if (entity == null)
+            throw new ArgumentNullException(nameof(entity));
+
+        if (!_models.TryGetValue(typeof(TEntity), out var model))
+            throw new InvalidOperationException($"Model for {typeof(TEntity).Name} is not registered.");
+
+        return KeyExtractor.ExtractKeyParts(entity, model);
+    }
+
     public (object Key, TEntity Value) ExtractKeyValue<TEntity>(TEntity entity) where TEntity : class
     {
         if (entity == null)
@@ -26,7 +37,8 @@ public class MappingManager : IMappingManager
 
         try
         {
-            var key = KeyExtractor.ExtractKeyValue(entity, model);
+            var parts = KeyExtractor.ExtractKeyParts(entity, model);
+            var key = KeyExtractor.BuildTypedKey(parts);
 
             if (key != null && key is not Dictionary<string, object> && !KeyExtractor.IsSupportedKeyType(key.GetType()))
             {

--- a/src/Messaging/Producers/Core/KafkaProducer.cs
+++ b/src/Messaging/Producers/Core/KafkaProducer.cs
@@ -50,7 +50,8 @@ internal class KafkaProducer<T> : IKafkaProducer<T> where T : class
 
         try
         {
-            var keyValue = KeyExtractor.ExtractKeyValue(message, _entityModel);
+            var parts = KeyExtractor.ExtractKeyParts(message, _entityModel);
+            var keyValue = KeyExtractor.BuildTypedKey(parts, _logger);
 
             var kafkaMessage = new Message<object, object>
             {

--- a/tests/Core/KeyExtractorTests.cs
+++ b/tests/Core/KeyExtractorTests.cs
@@ -127,4 +127,38 @@ public class KeyExtractorTests
         Assert.Equal("sample-topic", config.TopicName);
         Assert.Equal(2, config.KeyProperties.Length);
     }
+
+    [Fact]
+    public void ExtractKeyParts_WithCompositeKey_ReturnsParts()
+    {
+        var entity = new SampleEntity { Id = 1, Name = "A" };
+        var model = CreateModel();
+        var parts = KeyExtractor.ExtractKeyParts(entity, model);
+        Assert.Equal(2, parts.Count);
+        Assert.Equal("Id", parts[0].KeyName);
+        Assert.Equal(typeof(int), parts[0].KeyType);
+        Assert.Equal("1", parts[0].Value);
+        Assert.Equal("Name", parts[1].KeyName);
+        Assert.Equal(typeof(string), parts[1].KeyType);
+        Assert.Equal("A", parts[1].Value);
+    }
+
+    [Fact]
+    public void BuildTypedKey_RoundTrip_Works()
+    {
+        var entity = new SampleEntity { Id = 2, Name = "B" };
+        var model = CreateModel();
+        var parts = KeyExtractor.ExtractKeyParts(entity, model);
+        var obj = KeyExtractor.BuildTypedKey(parts);
+        var dict = Assert.IsType<Dictionary<string, object>>(obj);
+        Assert.Equal(2, dict["Id"]);
+        Assert.Equal("B", dict["Name"]);
+    }
+
+    [Fact]
+    public void BuildTypedKey_InvalidValue_Throws()
+    {
+        var parts = new List<CompositeKeyPart> { new("Id", typeof(int), "abc") };
+        Assert.ThrowsAny<Exception>(() => KeyExtractor.BuildTypedKey(parts));
+    }
 }

--- a/tests/Mapping/MappingManagerTests.cs
+++ b/tests/Mapping/MappingManagerTests.cs
@@ -140,4 +140,23 @@ public class MappingManagerTests
         var dict = Assert.IsType<Dictionary<string, object>>(result.Key);
         Assert.Equal(string.Empty, dict[nameof(NullComposite.Code)]);
     }
+
+    [Fact]
+    public void ExtractKeyParts_ReturnsTuples()
+    {
+        var builder = new ModelBuilder();
+        builder.Entity<CompositeSample>()
+            .WithTopic("composite")
+            .HasKey(e => new { e.Id, e.Code });
+        var model = builder.GetEntityModel<CompositeSample>()!;
+
+        var manager = new MappingManager();
+        manager.Register<CompositeSample>(model);
+
+        var entity = new CompositeSample { Id = 3, Code = "z" };
+        var parts = manager.ExtractKeyParts(entity);
+        Assert.Equal(2, parts.Count);
+        Assert.Equal("Id", parts[0].KeyName);
+        Assert.Equal("3", parts[0].Value);
+    }
 }


### PR DESCRIPTION
## Summary
- add `CompositeKeyPart` struct
- support tuple-based key extraction in `KeyExtractor`
- update `MappingManager` and `KafkaProducer` to use new API
- update docs and samples for recommended API
- add unit tests for new functionality
- record progress and diff logs

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --no-build -v minimal`
- `dotnet test physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68732d9ab59083278161d23061c73aa8