### PR TITLE
Update QuerySchema with key/value metadata

### DIFF
--- a/docs/changes/20250713_progress.md
+++ b/docs/changes/20250713_progress.md
@@ -43,3 +43,7 @@
 - Updated manager tests after serialization refactor
 - Simplified helper creation using real constructors
 - All unit tests pass with Confluent serializers
+## 2025-07-13 17:21 JST [assistant]
+- Query namespace を Key/Value メタ情報返却方式へ更新
+- QuerySchema, QueryAnalyzer, EntityModel 連携を改修
+- ドキュメントとdiff_logを追加しテスト実行

--- a/docs/diff_log/diff_query_schema_design_20250713.md
+++ b/docs/diff_log/diff_query_schema_design_20250713.md
@@ -1,0 +1,19 @@
+# 差分履歴: query_schema_design
+
+🗕 2025年7月13日（JST）
+🧐 作業者: assistant
+
+## 差分タイトル
+QuerySchema に Key/Value メタ情報を追加
+
+## 変更理由
+Query namespace 解析結果に論理 Key/Value 情報を提供し、MappingManager や Schema Registry 連携を容易にするため。
+
+## 追加・修正内容（反映先: oss_design_combined.md）
+- `KeyValueSchemaInfo` クラス新設
+- `QuerySchema` に `KeyInfo` と `ValueInfo` を追加しクラス名・namespace・バージョンを保持
+- EntityModel 保存文字列に Key/Value クラス名を含める
+- ドキュメント `query_namespace_doc.md` に設計転換を追記
+
+## 参考文書
+- `docs/namespaces/query_namespace_doc.md`

--- a/docs/namespaces/query_namespace_doc.md
+++ b/docs/namespaces/query_namespace_doc.md
@@ -126,3 +126,12 @@ Core.Abstractions → Query.Abstractions ← Query.Builders
 3. **3テーブル制限**: ストリーム処理性能のための制限
 4. **式木安全性**: 深度・複雑度制限によるスタックオーバーフロー防止
 5. **NULL安全**: 全Builder・Generatorで統一されたNULL処理
+
+## 論理Key/Valueメタ情報提供への転換
+
+2025-07-13 の設計変更により、Query namespace は LINQ 解析結果から
+"物理モデル" だけを抽出する方式を改め、論理 Key/Value 構造と
+クラス名・namespace を含むメタ情報を `QuerySchema` として返すよう統一した。
+このメタ情報は MappingManager とスキーマ生成ロジックに連携され、
+Kafka/Avro/Schema Registry まで一貫した管理を実現する。
+将来のスキーマバージョンや互換性フラグも `KeyInfo`/`ValueInfo` に拡張可能である。

--- a/src/Application/ksql-context-integration.cs
+++ b/src/Application/ksql-context-integration.cs
@@ -74,8 +74,8 @@ public static class KsqlContextQueryExtensions
             return null;
 
         // 正規表現でスキーマ情報をパース
-        var match = Regex.Match(schemaWarning, 
-            @"QuerySchema:Source=([^,]+),Target=([^,]+),Keys=(\d+),Type=([^,]+)");
+        var match = Regex.Match(schemaWarning,
+            @"QuerySchema:Source=([^,]+),Target=([^,]+),KeyClass=([^,]+),KeyNs=([^,]+),ValueClass=([^,]+),ValueNs=([^,]+),Keys=(\d+),Type=([^,]+)");
         
         if (!match.Success)
             return null;
@@ -84,18 +84,26 @@ public static class KsqlContextQueryExtensions
         {
             var sourceTypeName = match.Groups[1].Value;
             var targetTypeName = match.Groups[2].Value;
-            var keyCount = int.Parse(match.Groups[3].Value);
-            var streamTableType = match.Groups[4].Value;
+            var keyClass = match.Groups[3].Value;
+            var keyNs = match.Groups[4].Value;
+            var valueClass = match.Groups[5].Value;
+            var valueNs = match.Groups[6].Value;
+            var keyCount = int.Parse(match.Groups[7].Value);
+            var streamTableType = match.Groups[8].Value;
 
             var schema = new QuerySchema
             {
                 SourceType = Type.GetType(sourceTypeName) ?? entityModel.EntityType,
                 TargetType = entityModel.EntityType,
-                KeyProperties = entityModel.KeyProperties.Take(keyCount).ToArray(),
-                ValueProperties = entityModel.AllProperties,
                 TopicName = entityModel.TopicName ?? entityModel.EntityType.Name.ToLowerInvariant(),
                 IsValid = entityModel.IsValid
             };
+            schema.KeyInfo.ClassName = keyClass;
+            schema.KeyInfo.Namespace = keyNs;
+            schema.ValueInfo.ClassName = valueClass;
+            schema.ValueInfo.Namespace = valueNs;
+            schema.KeyProperties = entityModel.KeyProperties.Take(keyCount).ToArray();
+            schema.ValueProperties = entityModel.AllProperties;
 
             return schema;
         }

--- a/src/Core/Modeling/entity-builder-extensions.cs
+++ b/src/Core/Modeling/entity-builder-extensions.cs
@@ -149,8 +149,12 @@ public static class EntityBuilderQueryExtensions
         // （既存のEntityModel構造を変更せずに情報を保持）
         entityModel.ValidationResult ??= new ValidationResult { IsValid = true, Warnings = new() };
         
-        var schemaInfo = $"QuerySchema:Source={schema.SourceType.Name},Target={schema.TargetType.Name}," +
-                        $"Keys={schema.KeyProperties.Length},Type={schema.GetStreamTableType()}";
+        var schemaInfo =
+            $"QuerySchema:Source={schema.SourceType.FullName}," +
+            $"Target={schema.TargetType.FullName}," +
+            $"KeyClass={schema.KeyInfo.ClassName},KeyNs={schema.KeyInfo.Namespace}," +
+            $"ValueClass={schema.ValueInfo.ClassName},ValueNs={schema.ValueInfo.Namespace}," +
+            $"Keys={schema.KeyProperties.Length},Type={schema.GetStreamTableType()}";
         
         entityModel.ValidationResult.Warnings.Add(schemaInfo);
     }

--- a/src/Query/query-analyzer.cs
+++ b/src/Query/query-analyzer.cs
@@ -32,6 +32,11 @@ public static class QueryAnalyzer
                 TopicName = typeof(TTarget).Name.ToLowerInvariant()
             };
 
+            schema.KeyInfo.ClassName = $"{typeof(TTarget).Name}Key";
+            schema.KeyInfo.Namespace = typeof(TTarget).Namespace ?? string.Empty;
+            schema.ValueInfo.ClassName = $"{typeof(TTarget).Name}Value";
+            schema.ValueInfo.Namespace = typeof(TTarget).Namespace ?? string.Empty;
+
             // GroupBy解析
             if (visitor.GroupByExpression != null)
             {

--- a/src/Query/query-schema.cs
+++ b/src/Query/query-schema.cs
@@ -7,15 +7,36 @@ namespace Kafka.Ksql.Linq.Query.Schema;
 /// <summary>
 /// クエリによって生成されるKey/Value構造の定義
 /// </summary>
+public class KeyValueSchemaInfo
+{
+    public string ClassName { get; set; } = string.Empty;
+    public string Namespace { get; set; } = string.Empty;
+    public PropertyInfo[] Properties { get; set; } = Array.Empty<PropertyInfo>();
+    public string SchemaVersion { get; set; } = "1";
+    public string Compatibility { get; set; } = string.Empty;
+}
+
 public class QuerySchema
 {
     public Type SourceType { get; set; } = default!;
     public Type TargetType { get; set; } = default!;
-    public PropertyInfo[] KeyProperties { get; set; } = Array.Empty<PropertyInfo>();
-    public PropertyInfo[] ValueProperties { get; set; } = Array.Empty<PropertyInfo>();
+    public KeyValueSchemaInfo KeyInfo { get; set; } = new();
+    public KeyValueSchemaInfo ValueInfo { get; set; } = new();
     public string TopicName { get; set; } = string.Empty;
     public bool IsValid { get; set; }
     public List<string> Errors { get; set; } = new();
+
+    public PropertyInfo[] KeyProperties
+    {
+        get => KeyInfo.Properties;
+        set => KeyInfo.Properties = value;
+    }
+
+    public PropertyInfo[] ValueProperties
+    {
+        get => ValueInfo.Properties;
+        set => ValueInfo.Properties = value;
+    }
 
     /// <summary>
     /// 単一キーかどうか

--- a/tests/Query/QueryAnalyzerTests.cs
+++ b/tests/Query/QueryAnalyzerTests.cs
@@ -39,6 +39,8 @@ public class QueryAnalyzerTests
         Assert.Single(schema.KeyProperties);
         Assert.Equal(nameof(ApiMessage.Category), schema.KeyProperties[0].Name);
         Assert.Equal(2, schema.ValueProperties.Length);
+        Assert.Equal("CategoryCountKey", schema.KeyInfo.ClassName);
+        Assert.Equal("CategoryCountValue", schema.ValueInfo.ClassName);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- restructure `QuerySchema` to expose KeyInfo/ValueInfo metadata
- record key/value class information when persisting schema
- parse the enhanced metadata from entity models
- adapt `QueryAnalyzer` and tests
- document the switch to logical key/value metadata
- add diff log and progress log entry

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68736a9616988327bbb016db4a10606e