### PR TITLE
Document query to mapping flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,8 @@ NAME_MISMATCH等のエラー時は手動で該当subject削除後に再実行
 |--|--|
 | `docs/docs_advanced_rules.md` | [運用設計上の制約、設計判断の背景と意図](./docs/docs_advanced_rules.md) |
 | `docs/docs_configuration_reference.md` | [appsettings.json などの構成ファイルとマッピング解説](.docs/docs_configuration_reference.md) |
-| `docs/architecture_overview.md` | [全体アーキテクチャ構造と各層の責務定義] (./docs/architecture_overview.md)|
+| `docs/architecture_overview.md` | [全体アーキテクチャ構造と各層の責務定義](./docs/architecture_overview.md) |
+| `docs/architecture/query_ksql_mapping_flow.md` | [Query→KsqlContext→Mapping/Serialization 連携仕様](./docs/architecture/query_ksql_mapping_flow.md) |
 | `docs/test_guidelines.md` | [ksqlDB仕様準拠のテストガイドライン](./docs/test_guidelines.md) |
 | `docs/poco_design_policy.md` | [POCO設計・PK運用・シリアライズ方針](./docs/poco_design_policy.md) |
 - ドキュメントの重複・矛盾チェック結果は [docs/duplication_check_20250729.md](./docs/duplication_check_20250729.md) を参照

--- a/docs/architecture/query_ksql_mapping_flow.md
+++ b/docs/architecture/query_ksql_mapping_flow.md
@@ -1,0 +1,67 @@
+# Query -> KsqlContext -> Mapping/Serialization Flow
+
+🗕 2025-07-13 17:55 JST
+🧐 作成者: assistant
+
+Query namespace で組み立てた DSL から Messaging 層までの責務分界とデータフローを
+整理する。Messaging 再設計前の基準として、各レイヤーの役割と API 例を明記する。
+
+## 1. 目的
+- Query は LINQ 式から論理的な Key/Value 分割とメタ情報 (`QuerySchema`) を返す。
+- KsqlContext は `QuerySchema` を受け取り Mapping/Serialization へ変換指示する統括
+  レイヤーとなる。
+- Mapping/Serialization は POCO と Key/Value との相互変換、およびシリアライズ／
+  デシリアライズ処理を担当する。
+- Messaging は key/value の送受信 API のみを担う。
+
+## 2. 責務一覧
+| レイヤー | 主なクラス/IF | 責務概要 |
+| --- | --- | --- |
+| Query | `EntitySet<T>`, `QueryAnalyzer` | LINQ 式解析、`QuerySchema` 提供 |
+| KsqlContext | `KsqlContext`, `KsqlContextBuilder` | `QuerySchema` 登録、Mapping/Serialization への橋渡し |
+| Mapping | `MappingManager`, `PocoMapper` | `QuerySchema` を用いた POCO⇔Key/Value 変換 |
+| Serialization | `AvroSerializerFactory` 等 | Key/Value のシリアライズ／デシリアライズ |
+| Messaging | `IKafkaProducer<T>`, `IKafkaConsumer<TKey,TValue>` | Key/Value の送受信のみ |
+
+## 3. データフロー
+```mermaid
+sequenceDiagram
+    participant Q as Query
+    participant Ctx as KsqlContext
+    participant Map as Mapping
+    participant Ser as Serialization
+    participant Msg as Messaging
+
+    Q->>Ctx: QuerySchema
+    Ctx->>Map: Register(QuerySchema)
+    Ctx->>Ser: BuildSerializer(QuerySchema)
+    Ctx->>Msg: Produce(key,value)
+```
+
+1. `EntitySet<T>` から `QueryAnalyzer` が `QuerySchema` を生成。
+2. `KsqlContext` が `QuerySchema` を保持し、`MappingManager` へ登録。
+3. `KsqlContext` が `AvroSerializerFactory` へスキーマ情報を渡し、Serializer を生成。
+4. 生成された Key/Value は Messaging の `AddAsync(key,value)` へ渡され送信される。
+
+## 4. API 例
+```csharp
+// Query 側でメタ情報取得
+var result = QueryAnalyzer.Analyze<User, User>(q => q.Where(u => u.Id == 1));
+var schema = result.Schema!;
+
+// KsqlContext で登録
+var ctx = new MyKsqlContext(options);
+ctx.RegisterQuerySchema<User>(schema);
+
+// Mapping/Serialization を通じて送信
+var (key, value) = PocoMapper.ToKeyValue(user, schema);
+await ctx.Messaging.AddAsync(key, value);
+```
+
+## 5. Messaging 最小 API
+- `Task AddAsync(byte[] key, byte[] value, string topic);`
+- `IAsyncEnumerable<(byte[] Key, byte[] Value)> ConsumeAsync(string topic);`
+
+上記のように、Messaging 層はシリアライズ済みの key/value を送受信するだけに責務を絞
+る。KsqlContext は必要な型変換や Serializer の取得を行った上で Messaging を呼び出す。
+

--- a/docs/changes/20250713_progress.md
+++ b/docs/changes/20250713_progress.md
@@ -49,3 +49,5 @@
 - ドキュメントとdiff_logを追加しテスト実行
 ## 2025-07-13 17:43 JST [assistant]
 - Mapping namespace を PocoMapper の単一クラスに整理。テストとドキュメントを更新。
+## 2025-07-13 17:56 JST [assistant]
+- Query→KsqlContext→Mapping/Serialization の責務をまとめた新規ドキュメントを作成。Messaging namespace ドキュメントを最小 API 方針に更新。README へリンク追加。

--- a/docs/diff_log/diff_query_ksql_mapping_flow_20250713.md
+++ b/docs/diff_log/diff_query_ksql_mapping_flow_20250713.md
@@ -1,0 +1,19 @@
+# 差分履歴: query_ksql_mapping_flow
+
+🗕 2025年7月13日（JST）
+🧐 作業者: assistant
+
+## 差分タイトル
+Query→KsqlContext→Mapping/Serialization 連携仕様ドキュメント追加
+
+## 変更理由
+Messaging 再設計に向け、責務境界と API の流れを明文化するため。
+
+## 追加・修正内容（反映先: oss_design_combined.md）
+- `docs/architecture/query_ksql_mapping_flow.md` を新規作成
+- `docs/namespaces/messaging_namespace_doc.md` を最小 API 方針に更新
+- `README.md` に新ドキュメントへのリンクを追加
+
+## 参考文書
+- `docs/architecture_overview.md`
+- `docs/structure/shared/key_value_flow.md`

--- a/docs/namespaces/messaging_namespace_doc.md
+++ b/docs/namespaces/messaging_namespace_doc.md
@@ -1,7 +1,7 @@
 # Kafka.Ksql.Linq.Messaging 責務ドキュメント
 
 ## 概要
-Kafka メッセージング機能の型安全な抽象化層を提供する namespace。Producer/Consumer の統一管理、設定管理、エラーハンドリング（DLQ）を担当。
+Kafka メッセージング機能の型安全な抽象化層を提供する namespace。Producer/Consumer の統一管理、設定管理、エラーハンドリング（DLQ）を担当。新アーキテクチャでは **key/value の送受信のみを担う最小 API** へ責務を絞る。
 
 ## 主要な責務
 


### PR DESCRIPTION
## Summary
- specify Query→KsqlContext→Mapping/Serialization flow and minimal Messaging API
- link new doc from README
- note minimal responsibility in Messaging namespace doc
- record architecture diff and progress log

## Testing
- `dotnet test Kafka.Ksql.Linq.Tests.csproj -v diag`

------
https://chatgpt.com/codex/tasks/task_e_687373cc2070832790a7efecab0ec050