### PR TITLE
Update viewpoint docs on key-value flow

### DIFF
--- a/docs/changes/20250713_progress.md
+++ b/docs/changes/20250713_progress.md
@@ -51,3 +51,5 @@
 - Mapping namespace を PocoMapper の単一クラスに整理。テストとドキュメントを更新。
 ## 2025-07-13 17:56 JST [assistant]
 - Query→KsqlContext→Mapping/Serialization の責務をまとめた新規ドキュメントを作成。Messaging namespace ドキュメントを最小 API 方針に更新。README へリンク追加。
+## 2025-07-13 12:34 JST [assistant]
+- key_value_flow.md 更新内容を各担当視点ドキュメントへ反映

--- a/docs/structure/amagi/key_value_flow_amagi.md
+++ b/docs/structure/amagi/key_value_flow_amagi.md
@@ -6,7 +6,6 @@
 
 ```
 Query
-  ↳ POCO-Query Mapping
       ↳ KsqlContext
           ↳ Messaging
               ↳ Serialization
@@ -14,14 +13,14 @@ Query
 ```
 
 1. **Query**: DSL入力とLINQ式を担当。最初に仕様変更の影響を受ける。
-2. **POCO-Query Mapping**: `MappingManager` により POCO とクエリの対応関係を管理。
-3. **KsqlContext**: 構成情報を集中管理し、Pipeline初期化を行うハブ。
-4. **Messaging**: Kafka とのやり取りを抽象化。プロデューサ/コンシューマの両責任を持つ。
-5. **Serialization**: Avroスキーマの生成と変換。互換性維持が重要なため、更新は慎重に。
-6. **Kafka**: 実行基盤。外部依存のためテスト環境と本番環境の切り替えを明確化する。
+2. **KsqlContext**: 構成情報を集中管理し、Pipeline初期化を行うハブ。
+3. **Messaging**: Kafka とのやり取りを抽象化。プロデューサ/コンシューマの両責任を持つ。
+4. **Serialization**: Avroスキーマの生成と変換。互換性維持が重要なため、更新は慎重に。
+5. **Kafka**: 実行基盤。外部依存のためテスト環境と本番環境の切り替えを明確化する。
 
 ## 優先度マップ
 
+MappingManager の登録処理は KsqlContext 初期化と同時にまとめて実施する。
 | 項目 | 優先度 | 管理方針 |
 |-----|-------|---------|
 | スキーマ互換性 | 高 | 変更時は必ず `diff_log` に記録し、全チームでレビュー |

--- a/docs/structure/kyouka/key_value_flow_kyouka.md
+++ b/docs/structure/kyouka/key_value_flow_kyouka.md
@@ -5,8 +5,7 @@
 ## 構造上のポイント
 
 - **責務集中**: `KsqlContext` がProduce/Consumeを統括する一方、シリアライズ処理は `AvroSerializer` に限定されています。役割の境界が明確で、拡張や差し替えが容易です。
-- **マッピング層**: `MappingManager` を中心とした POCO-Query Mapping Layer が新設され、POCO と KSQL の対応を一元管理します。
-- **依存順序**: Query → POCO-Query Mapping → Context → Messaging → Serialization → Kafka の一方向依存になっており、逆方向参照はありません。
+- **依存順序**: Query → Context → Messaging → Serialization → Kafka の一方向依存で、逆参照はありません。
 - **結合度**: Messaging と Serialization はインターフェース経由で連携し、具象実装を隠蔽しています。
 
 ## 再整理に向けたコメント

--- a/docs/structure/shion/key_value_flow_shion.md
+++ b/docs/structure/shion/key_value_flow_shion.md
@@ -8,10 +8,9 @@
 
 | レイヤー        | 対象クラス例                  | 主なテスト内容 |
 |-----------------|------------------------------|----------------|
-| Query           | `EntitySet<T>`               | LINQ式からのKey生成の妥当性 |
-| POCO-Query Mapping | `MappingManager`             | クエリとPOCOのマッピング定義検証 |
-| Context         | `KsqlContext`, `KsqlContextBuilder` | オプション設定と依存注入の組み合わせ |
+| Query           | `EntitySet<T>`               | LINQ式からのKey生成の妥当性 || Context         | `KsqlContext`, `KsqlContextBuilder` | オプション設定と依存注入の組み合わせ |
 | Messaging       | `KafkaProducer`, `KafkaConsumer` | トピック送受信時の例外処理とリトライ確認 |
+| Application  | Consumer Handler       | ハンドラ呼び出しと後処理の検証 |
 | Serialization   | `AvroSerializer`, `AvroDeserializer` | スキーマ互換性とエラー時の挙動 |
 | Kafka           | テストブローカー             | 実際の配信確認（統合試験） |
 


### PR DESCRIPTION
## Summary
- align per-role docs with the updated shared `key_value_flow.md`
- note MappingManager registration with KsqlContext
- log the update in progress notes

## Testing
- `dotnet test --no-build --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6873a6d0f06c832783b11b932b8a007c