### PR TITLE
Update viewpoint docs for mapping flow

### DIFF
--- a/docs/changes/20250731_progress.md
+++ b/docs/changes/20250731_progress.md
@@ -3,3 +3,6 @@
 - CI 環境の NuGet 復元失敗を調査し actions/cache などの対策を試行
 - ドキュメント運用改善として重複箇所整理と新規メンバー向け早見表を更新
 - architecture_restart.md へ追加論点を追記し diff_log/architecture_diff_20250730.md に記録
+## 2025-07-13 13:14 JST [assistant]
+- shared key_value_flow 更新に合わせ各担当視点ドキュメントを追記
+

--- a/docs/structure/amagi/key_value_flow_amagi.md
+++ b/docs/structure/amagi/key_value_flow_amagi.md
@@ -30,3 +30,13 @@ MappingManager の登録処理は KsqlContext 初期化と同時にまとめて�
 | テスト環境 | 高 | 詩音と協力し、Kafkaブローカーの模擬環境を常に整備 |
 
 全体の進捗と課題は `docs/changes/` に記録し、週次でレビューします。
+
+## 型情報管理とMessagingの分離
+
+shared版で追加された [型情報・設計情報管理フロー](../shared/key_value_flow.md#8-%E5%9E%8B%E6%83%85%E5%A0%B1%E3%83%BB%E8%A8%AD%E8%A8%88%E6%83%85%E5%A0%B1%E7%AE%A1%E7%90%86%E3%83%95%E3%83%AD%E3%83%BC) を踏まえ、PM視点では次の点を管理指針とします。
+
+1. **PropertyMeta集中管理**: Fluent APIで確定した型情報を `PropertyMeta` として集約し、変更時はMappingManager経由でのみ更新する。
+2. **Messaging責務の純化**: key/valueのバイト列送受信に専念させ、設計変更の波及を避ける。
+3. **設計進化時の通知**: 新規POCO追加や属性変更はMapping登録フローの更新を必須とし、進捗ログに記録する。
+
+この方針に沿って進捗管理・レビューを行います。

--- a/docs/structure/kyouka/key_value_flow_kyouka.md
+++ b/docs/structure/kyouka/key_value_flow_kyouka.md
@@ -37,3 +37,8 @@
 - QueryBuilder が MappingManager の内部辞書へ直接アクセスするとテストが困難になる。インターフェース越しの連携に留めること。
 - KsqlContextBuilder が QueryBuilder の状態を変更すると Builder の再利用性が下がるため、設定オブジェクトを明確に分離する。
 - 各層で Fail-Fast ポリシーを徹底し、未登録モデル利用時は即例外を投げる。
+
+### 型情報管理レビュー
+- `PropertyMeta` による型情報の集中管理を正式ルールとし、Mapping 以外の層で型定義を持たないことを確認。
+- Messaging 層はバイト列処理のみを担当し、Mapping 更新時の影響範囲を最小化する構造を維持する。
+- 新しい POCO 追加時は必ず MappingManager 登録フローが実行されているかを監査ポイントとする。

--- a/docs/structure/naruse/key_value_flow_naruse.md
+++ b/docs/structure/naruse/key_value_flow_naruse.md
@@ -73,3 +73,9 @@ await context.AddAsync(entity);
 - `MappingManager` へ登録するモデルは `OnModelCreating` で一括定義する。
 - `QueryBuilder` から返される KSQL 文はデバッグログで確認しておく。
 - `KsqlContext` のライフサイクルは DI コンテナに任せ、使い回しを避ける。
+
+## Mapping拡張の実装ポイント
+sharedドキュメントの型情報管理フローを受け、実装担当として以下を意識します。
+1. `PropertyMeta` 定義は Fluent API で決定し、クラス属性には依存しない。
+2. `MappingManager` で自動生成される KeyType/ValueType を中心に型情報をやり取りする。
+3. Messaging 層には型を渡さず、バイト列のみでやり取りすることで実装の安定度を高める。

--- a/docs/structure/shion/key_value_flow_shion.md
+++ b/docs/structure/shion/key_value_flow_shion.md
@@ -36,4 +36,10 @@
 - `KsqlContext` との連携で key/value 抽出後に Kafka へ送信できる
 - Mapping 定義のない型を使用した場合にパイプライン全体で失敗を検知できる
 
+## Mappingテスト追加方針
+sharedの新セクションで定義された型情報管理フローを踏まえ、以下を重点的に検証します。
+1. `PropertyMeta` から生成される KeyType/ValueType が期待どおりか。
+2. MappingManager 更新時に Messaging 層への影響がないことを統合テストで保証。
+3. 新規POCO追加時に登録漏れが発生した場合のFail-Fast動作。
+
 エッジケースおよび失敗系は `tests/Mapping/MappingManager_viewpoints.md` に詳しく記述します。


### PR DESCRIPTION
## Summary
- add PropertyMeta/Messaging notes in Amagi view
- audit Mapping updates in Kyouka view
- list Mapping extension points in Naruse view
- outline new Mapping tests in Shion view
- log the documentation updates

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873b06475848327bb728b77bf503519