### PR TITLE
Update mapping-based serialization

### DIFF
--- a/docs/architecture/key_value_flow.md
+++ b/docs/architecture/key_value_flow.md
@@ -163,6 +163,7 @@ await ctx.AddAsync(entity);
 ### 8.3 Serialization/Deserializationの流れ
 - シリアライズ/デシリアライズ時はMappingからkey/value型＋PropertyMeta[]を取得し、Confluent.Avro公式ライブラリで変換処理を行う。
 - POCO⇄key/value⇄バイト列の流れで、型安全・設計一貫性を担保。
+- POCO⇄key/valueの分割・統合は`KeyValueTypeMapping`に備わるAPIを通じて行い、POCO型へのリフレクションや独自プロパティ探索は行わない。
 
 ### 8.4 Messaging層の責務純化
 - Messagingは型や属性・設計情報を一切保持せず、keyBytes/valueBytes/トピック名の送受信に専念する。

--- a/docs/changes/20250730_progress.md
+++ b/docs/changes/20250730_progress.md
@@ -3,3 +3,5 @@
 - RocksDB 検証計画や Confluent 依存管理など追加論点を整理
 - メトリクス内製をやめ、DLQ利用方針を明確化
 - diff_log/architecture_diff_20250730.md として変更内容を記録
+## 2025-07-13 23:32 JST [naruse]
+- Serialization mapping API強化とドキュメント更新を実施。KeyValueTypeMappingからの抽出/統合メソッドを追加。

--- a/docs/structure/shared/key_value_flow.md
+++ b/docs/structure/shared/key_value_flow.md
@@ -163,6 +163,7 @@ await ctx.AddAsync(entity);
 ### 8.3 Serialization/Deserializationの流れ
 - シリアライズ/デシリアライズ時はMappingからkey/value型＋PropertyMeta[]を取得し、Confluent.Avro公式ライブラリで変換処理を行う。
 - POCO⇄key/value⇄バイト列の流れで、型安全・設計一貫性を担保。
+- POCO⇄key/valueの変換は`KeyValueTypeMapping`提供のAPIを用い、POCO型へのリフレクションや独自探索を行わない。
 
 ### 8.4 Messaging層の責務純化
 - Messagingは型や属性・設計情報を一切保持せず、keyBytes/valueBytes/トピック名の送受信に専念する。

--- a/src/Mapping/KeyValueTypeMapping.cs
+++ b/src/Mapping/KeyValueTypeMapping.cs
@@ -2,6 +2,7 @@ namespace Kafka.Ksql.Linq.Mapping;
 
 using Kafka.Ksql.Linq.Core.Models;
 using System;
+using System.Reflection;
 
 /// <summary>
 /// Holds generated key/value types and their associated PropertyMeta information.
@@ -10,6 +11,72 @@ public class KeyValueTypeMapping
 {
     public Type KeyType { get; set; } = default!;
     public PropertyMeta[] KeyProperties { get; set; } = Array.Empty<PropertyMeta>();
+    public PropertyInfo[] KeyTypeProperties { get; set; } = Array.Empty<PropertyInfo>();
+
     public Type ValueType { get; set; } = default!;
     public PropertyMeta[] ValueProperties { get; set; } = Array.Empty<PropertyMeta>();
+    public PropertyInfo[] ValueTypeProperties { get; set; } = Array.Empty<PropertyInfo>();
+
+    /// <summary>
+    /// Extract key object from POCO instance based on registered PropertyMeta.
+    /// </summary>
+    public object ExtractKey(object poco)
+    {
+        if (poco == null) throw new ArgumentNullException(nameof(poco));
+        var keyInstance = Activator.CreateInstance(KeyType)!;
+        for (int i = 0; i < KeyProperties.Length; i++)
+        {
+            var meta = KeyProperties[i];
+            var value = meta.PropertyInfo!.GetValue(poco);
+            KeyTypeProperties[i].SetValue(keyInstance, value);
+        }
+        return keyInstance;
+    }
+
+    /// <summary>
+    /// Extract value object from POCO instance based on registered PropertyMeta.
+    /// </summary>
+    public object ExtractValue(object poco)
+    {
+        if (poco == null) throw new ArgumentNullException(nameof(poco));
+        var valueInstance = Activator.CreateInstance(ValueType)!;
+        for (int i = 0; i < ValueProperties.Length; i++)
+        {
+            var meta = ValueProperties[i];
+            var value = meta.PropertyInfo!.GetValue(poco);
+            ValueTypeProperties[i].SetValue(valueInstance, value);
+        }
+        return valueInstance;
+    }
+
+    /// <summary>
+    /// Combine key and value objects into a POCO instance of the specified type.
+    /// </summary>
+    public object CombineFromKeyValue(object? key, object value, Type pocoType)
+    {
+        if (value == null) throw new ArgumentNullException(nameof(value));
+        if (pocoType == null) throw new ArgumentNullException(nameof(pocoType));
+
+        var instance = Activator.CreateInstance(pocoType)!;
+
+        // set value properties
+        for (int i = 0; i < ValueProperties.Length; i++)
+        {
+            var meta = ValueProperties[i];
+            var val = ValueTypeProperties[i].GetValue(value);
+            meta.PropertyInfo!.SetValue(instance, val);
+        }
+
+        if (key != null)
+        {
+            for (int i = 0; i < KeyProperties.Length; i++)
+            {
+                var meta = KeyProperties[i];
+                var val = KeyTypeProperties[i].GetValue(key);
+                meta.PropertyInfo!.SetValue(instance, val);
+            }
+        }
+
+        return instance;
+    }
 }

--- a/src/Mapping/MappingRegistry.cs
+++ b/src/Mapping/MappingRegistry.cs
@@ -2,6 +2,7 @@ using Kafka.Ksql.Linq.Core.Models;
 using System;
 using System.Collections.Concurrent;
 using System.Reflection;
+using System.Linq;
 using System.Reflection.Emit;
 
 namespace Kafka.Ksql.Linq.Mapping;
@@ -33,12 +34,21 @@ public class MappingRegistry
         var keyType = CreateType(ns, $"{baseName}-key", keyProperties);
         var valueType = CreateType(ns, $"{baseName}-value", valueProperties);
 
+        var keyTypeProps = keyProperties
+            .Select(p => keyType.GetProperty(p.Name)!)
+            .ToArray();
+        var valueTypeProps = valueProperties
+            .Select(p => valueType.GetProperty(p.Name)!)
+            .ToArray();
+
         var mapping = new KeyValueTypeMapping
         {
             KeyType = keyType,
             KeyProperties = keyProperties,
+            KeyTypeProperties = keyTypeProps,
             ValueType = valueType,
-            ValueProperties = valueProperties
+            ValueProperties = valueProperties,
+            ValueTypeProperties = valueTypeProps
         };
         _mappings[pocoType] = mapping;
         return mapping;

--- a/tests/Mapping/KeyValueTypeMappingMethodsTests.cs
+++ b/tests/Mapping/KeyValueTypeMappingMethodsTests.cs
@@ -1,0 +1,37 @@
+using Kafka.Ksql.Linq.Core.Models;
+using Kafka.Ksql.Linq.Mapping;
+using System.Linq;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Mapping;
+
+public class KeyValueTypeMappingMethodsTests
+{
+    private class Sample
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    public void ExtractAndCombine_RoundTrip_ReturnsEquivalentObject()
+    {
+        var registry = new MappingRegistry();
+        var keyProps = new[] { PropertyMeta.FromProperty(typeof(Sample).GetProperty(nameof(Sample.Id))!) };
+        var valueProps = typeof(Sample).GetProperties()
+            .Select(p => PropertyMeta.FromProperty(p))
+            .ToArray();
+
+        var mapping = registry.Register(typeof(Sample), keyProps, valueProps);
+
+        var sample = new Sample { Id = 5, Name = "x" };
+
+        var keyObj = mapping.ExtractKey(sample);
+        var valueObj = mapping.ExtractValue(sample);
+
+        var restored = (Sample)mapping.CombineFromKeyValue(keyObj, valueObj, typeof(Sample));
+
+        Assert.Equal(sample.Id, restored.Id);
+        Assert.Equal(sample.Name, restored.Name);
+    }
+}


### PR DESCRIPTION
## Summary
- add Extract/Combine helpers to `KeyValueTypeMapping`
- store dynamic type property infos in `MappingRegistry`
- document reflection prohibition in key/value flow (architecture docs)
- add unit test for new helpers
- log progress

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_6873c2102ce88327a91c666d13a094fd