### PR TITLE
Add read/write access mode for entities

### DIFF
--- a/docs/changes/20250731_progress.md
+++ b/docs/changes/20250731_progress.md
@@ -19,3 +19,6 @@
 - refactored KafkaConsumerManager to accept DLQ action delegate
 - updated consumers and context to wire DlqProducer via delegate
 - adjusted tests to use delegate
+## 2025-07-14 03:32 JST [naruse]
+- Entity access mode flags (readOnly/writeOnly) added to ModelBuilder
+- Updated SampleContext and design docs with new parameters

--- a/docs/fluent_api_initial_design.md
+++ b/docs/fluent_api_initial_design.md
@@ -9,6 +9,7 @@
 - `docs/core_namespace_redesign_plan.md` で示されたとおり、`TopicAttribute` などの属性は削除予定。
 - `IEntityBuilder<T>` を介してキーやトピックなどを宣言的に設定する。
 - `HasKey` は必須呼び出しとし、複合キーも `HasKey(e => new { e.A, e.B })` で定義する。
+- エンティティ登録時に `readOnly` または `writeOnly` フラグを指定でき、未指定時は両用となる。
 
 ## 2. 推奨 Fluent API 記述例
 ```csharp
@@ -20,12 +21,10 @@ class Order
 
 void OnModelCreating(ModelBuilder builder)
 {
-    builder.Entity<Order>(b =>
-    {
-        b.HasKey(o => o.Id);
-        b.WithTopic("orders");
-        b.WithDecimalPrecision(o => o.Amount, precision: 18, scale: 2);
-    });
+    builder.Entity<Order>(writeOnly: true)
+        .HasKey(o => o.Id)
+        .WithTopic("orders")
+        .WithDecimalPrecision(o => o.Amount, precision: 18, scale: 2);
 }
 ```
 上記により、旧 `[Topic]` や `DecimalPrecision` 属性を使用せずにトピックや精度を設定できる。

--- a/src/Core/Abstractions/EntityAccessMode.cs
+++ b/src/Core/Abstractions/EntityAccessMode.cs
@@ -1,0 +1,23 @@
+namespace Kafka.Ksql.Linq.Core.Abstractions;
+
+/// <summary>
+/// Specifies whether an entity is used for reads, writes, or both.
+/// </summary>
+public enum EntityAccessMode
+{
+    /// <summary>
+    /// Entity is used for both read and write operations.
+    /// </summary>
+    ReadWrite,
+
+    /// <summary>
+    /// Entity is only used for reading from Kafka topics.
+    /// </summary>
+    ReadOnly,
+
+    /// <summary>
+    /// Entity is only used for writing to Kafka topics.
+    /// </summary>
+    WriteOnly
+}
+

--- a/src/Core/Abstractions/EntityModel.cs
+++ b/src/Core/Abstractions/EntityModel.cs
@@ -17,6 +17,11 @@ public class EntityModel
 
     public PropertyInfo[] AllProperties { get; set; } = Array.Empty<PropertyInfo>();
 
+    /// <summary>
+    /// Indicates whether this entity is used for reading, writing, or both.
+    /// </summary>
+    public EntityAccessMode AccessMode { get; set; } = EntityAccessMode.ReadWrite;
+
     public ValidationResult? ValidationResult { get; set; }
 
     public bool IsValid => ValidationResult?.IsValid ?? false;

--- a/src/Core/Abstractions/IModelBuilder.cs
+++ b/src/Core/Abstractions/IModelBuilder.cs
@@ -2,5 +2,12 @@ namespace Kafka.Ksql.Linq.Core.Abstractions;
 
 public interface IModelBuilder
 {
-    IEntityBuilder<T> Entity<T>() where T : class;
+    /// <summary>
+    /// Registers an entity type in the model and optionally marks it as read-only or write-only.
+    /// </summary>
+    /// <param name="readOnly">If true, the entity is used only for reads.</param>
+    /// <param name="writeOnly">If true, the entity is used only for writes.</param>
+    /// <typeparam name="T">Entity type.</typeparam>
+    /// <returns>An <see cref="IEntityBuilder{T}"/> for further configuration.</returns>
+    IEntityBuilder<T> Entity<T>(bool readOnly = false, bool writeOnly = false) where T : class;
 }

--- a/src/Core/Modeling/ModelBuilder.cs
+++ b/src/Core/Modeling/ModelBuilder.cs
@@ -15,14 +15,22 @@ internal class ModelBuilder : IModelBuilder
     {
         _validationMode = validationMode;
     }
-    public IEntityBuilder<T> Entity<T>() where T : class
+    public IEntityBuilder<T> Entity<T>(bool readOnly = false, bool writeOnly = false) where T : class
     {
+        if (readOnly && writeOnly)
+            throw new ArgumentException("Cannot specify both readOnly and writeOnly");
+
         AddEntityModel<T>();
         var model = GetEntityModel<T>();
         if (model == null)
         {
             throw new InvalidOperationException($"Failed to create entity model for {typeof(T).Name}");
         }
+
+        model.AccessMode = readOnly ? EntityAccessMode.ReadOnly :
+                           writeOnly ? EntityAccessMode.WriteOnly :
+                           EntityAccessMode.ReadWrite;
+
         return new EntityModelBuilder<T>(model);
     }
     public EntityModel? GetEntityModel<T>() where T : class

--- a/src/Entities/Samples/SampleContext.cs
+++ b/src/Entities/Samples/SampleContext.cs
@@ -19,7 +19,7 @@ public class SampleContext : KafkaContextCore
 
     protected override void OnModelCreating(IModelBuilder modelBuilder)
     {
-        modelBuilder.Entity<User>()
+        modelBuilder.Entity<User>(readOnly: true)
             .WithTopic("users")
             .HasKey(u => u.Id);
 
@@ -27,7 +27,7 @@ public class SampleContext : KafkaContextCore
             .WithTopic("products")
             .HasKey(p => p.ProductId);
 
-        modelBuilder.Entity<Order>()
+        modelBuilder.Entity<Order>(writeOnly: true)
             .WithTopic("orders")
             .HasKey(o => new { o.OrderId, o.UserId });
     }


### PR DESCRIPTION
## Summary
- introduce `EntityAccessMode` enum
- allow specifying `readOnly` and `writeOnly` flags when calling `ModelBuilder.Entity`
- store access mode in `EntityModel`
- update sample usage and design documentation
- record progress update

## Testing
- `dotnet test Kafka.Ksql.Linq.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6874782437ac8327aab7cfa922852aa0