### PR TITLE
Add PM directive for entity access roles

### DIFF
--- a/Reportsx/tenjo/20250714_entity_access_policy.md
+++ b/Reportsx/tenjo/20250714_entity_access_policy.md
@@ -1,0 +1,21 @@
+# Entity役割指定方針・API統一
+発信者：天城（PM/司令）
+宛先：@all
+日付：2025-07-14 (JST)
+
+## 概要
+Entity/Fluent API/設計情報での役割指定を以下の3種類に統一します。
+- `readonly`
+- `writeonly`
+- `readwrite`（未指定時のデフォルト）
+
+Mapping, Messaging, KsqlContext など全ての設計情報と API でこの役割を参照し、処理を分岐してください。クラウド用語（例: Pod）を避け、DB・業務開発で一般的な単語へ置き換えることも併せて実施します。
+
+## 具体例
+```csharp
+modelBuilder.Entity<User>(readonly: true);
+modelBuilder.Entity<Order>(writeonly: true);
+// 何も指定しなければ readwrite
+```
+
+設計書・サンプルコード・APIドキュメントを順次更新し、役割分離と可読性向上を徹底してください。

--- a/docs/changes/20250714_progress.md
+++ b/docs/changes/20250714_progress.md
@@ -1,0 +1,4 @@
+## 2025-07-14 00:12 JST [tenjo]
+- Entity役割指定方法を readonly/writeonly/readwrite の3種類に統一するPM指示を発信
+- 関連ドキュメント修正方針を Reportsx/tenjo/20250714_entity_access_policy.md に記録
+- diff_log/diff_entity_access_policy_20250714.md を追加して設計変更を共有

--- a/docs/diff_log/diff_entity_access_policy_20250714.md
+++ b/docs/diff_log/diff_entity_access_policy_20250714.md
@@ -1,0 +1,18 @@
+# 差分履歴: entity_access_policy
+
+🗕 2025年7月14日（JST）
+🧐 作業者: 天城
+
+## 差分タイトル
+Entity役割指定方法の統一
+
+## 変更理由
+OSS 全体で Entity の利用目的を明確化し、API 設計の一貫性を高めるため。
+
+## 追加・修正内容（反映先: oss_design_combined.md）
+- Entity 登録時の役割を `readonly` `writeonly` `readwrite` の3種類とする方針を追加
+- Mapping/Messaging/KsqlContext など関連 API もこの役割判定で分岐する旨を追記
+- K8s 用語を排除し、一般的な DB 用語で統一する指示を明示
+
+## 参考文書
+- `fluent_api_initial_design.md`

--- a/docs/fluent_api_initial_design.md
+++ b/docs/fluent_api_initial_design.md
@@ -9,7 +9,7 @@
 - `docs/core_namespace_redesign_plan.md` で示されたとおり、`TopicAttribute` などの属性は削除予定。
 - `IEntityBuilder<T>` を介してキーやトピックなどを宣言的に設定する。
 - `HasKey` は必須呼び出しとし、複合キーも `HasKey(e => new { e.A, e.B })` で定義する。
-- エンティティ登録時に `readOnly` または `writeOnly` フラグを指定でき、未指定時は両用となる。
+- エンティティ登録時は `readonly` `writeonly` `readwrite` の3種類で役割を指定する。未指定時は `readwrite` とみなす。
 
 ## 2. 推奨 Fluent API 記述例
 ```csharp


### PR DESCRIPTION
## Summary
- document new policy for entity role flags
- note policy in progress log
- add diff log entry
- clarify default `readwrite` in fluent API design doc

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj -v n`

------
https://chatgpt.com/codex/tasks/task_e_68747b8f8d088327be993f428bf93c2b