### PR TITLE
Enable decimal and DateTimeOffset parsing

### DIFF
--- a/docs/changes/20250714_progress.md
+++ b/docs/changes/20250714_progress.md
@@ -23,3 +23,6 @@
 ## 2025-07-14 19:13 JST [assistant]
 - Fixed SchemaRegistryMetaProvider build errors and ensured dotnet test runs (all tests skipped)
 
+## 2025-07-14 22:52 JST [assistant]
+- SchemaRegistryMetaProvider now parses decimal precision/scale and timestamp-millis
+- Executed dotnet build and test (tests skipped)


### PR DESCRIPTION
## Summary
- extend `SchemaRegistryMetaProvider` to parse logical decimal and timestamp schemas
- record progress

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68750a0505f483278678a7660b418f12