### PR TITLE
Remove auto DLQ on producer error

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -448,6 +448,7 @@ AIは、指摘内容・理由を自動で集約・要約し、「現場設計Pro
 - [2025-07-22 楠木レポート](Reportsx/kusunoki/20250722_kusunoki_report.md)
 - [2025-07-27 楠木レポート](Reportsx/kusunoki/20250727_kusunoki_report.md)
 - [2025-07-12 広夢レポート](Reportsx/hiromu/20250712_hiromu_report.md)
+- [2025-07-17 差分ログ](docs/diff_log/diff_remove_producer_error_dlq_20250717.md)
 
 ## イレギュラー対応ルール
 

--- a/docs/diff_log/diff_remove_producer_error_dlq_20250717.md
+++ b/docs/diff_log/diff_remove_producer_error_dlq_20250717.md
@@ -1,0 +1,17 @@
+# 差分履歴: remove_producer_error_dlq
+
+🗕 2025年7月17日（JST）
+🧐 作業者: codex
+
+## 差分タイトル
+Producer エラー時の自動 DLQ 送信を廃止
+
+## 変更理由
+送信エラー時に DLQ へ転送する処理が期待通り動作しないため、KsqlContext から自動送信ハンドラを削除し、利用側で必要に応じて DLQ を呼び出す方式へ戻す。
+
+## 追加・修正内容（反映先: oss_design_combined.md）
+- `KsqlContext` で `KafkaProducerManager.ProduceError` への登録を削除
+- 自動 DLQ 送信は利用者実装に任せる設計へ変更
+
+## 参考文書
+- `docs/api_reference.md`

--- a/src/KsqlContext.cs
+++ b/src/KsqlContext.cs
@@ -69,30 +69,6 @@ public abstract class KsqlContext : KafkaContextCore
                 new DlqOptions { TopicName = _dslOptions.DlqTopicName });
             _dlqProducer.InitializeAsync().GetAwaiter().GetResult();
 
-            _producerManager.ProduceError += (msg, ctx, ex) =>
-            {
-                var errorContext = new ErrorContext
-                {
-                    Exception = ex,
-                    OriginalMessage = msg,
-                    AttemptCount = 1,
-                    FirstAttemptTime = DateTime.UtcNow,
-                    LastAttemptTime = DateTime.UtcNow,
-                    ErrorPhase = "Producer"
-                };
-
-                var messageContext = ctx ?? new KafkaMessageContext
-                {
-                    MessageId = Guid.NewGuid().ToString(),
-                    Tags = new System.Collections.Generic.Dictionary<string, object>
-                    {
-                        ["original_topic"] = ctx?.Tags.GetValueOrDefault("topic")?.ToString() ?? string.Empty
-                    }
-                };
-
-                return _dlqProducer.HandleErrorAsync(errorContext, messageContext);
-            };
-
             _consumerManager = new KafkaConsumerManager(
                 Microsoft.Extensions.Options.Options.Create(_dslOptions),
                 null);


### PR DESCRIPTION
## Summary
- drop automatic DLQ sending on producer errors in `KsqlContext`
- document the design change
- log the update in `AGENTS.md`

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6878c3433a20832784733017553ebb2c