### PR TITLE
Implement serializer caching for Kafka managers

### DIFF
--- a/docs/changes/20250717_progress.md
+++ b/docs/changes/20250717_progress.md
@@ -1,0 +1,8 @@
+## 2025-07-17 21:22 JST [assistant]
+- KafkaProducerManager/KafkaConsumerManager の責務をドキュメントに追記
+- appsettings 仕様に ProducerSection/ConsumerSection 対応を明記
+- Messaging 層の Avro 変換とキャッシュ化を設計資料に反映
+- Serializer/Deserializer キャッシュ実装とテストを追加
+## 2025-07-17 21:42 JST [assistant]
+- Removed redundant SendError event wiring in KafkaProducerManager
+

--- a/docs/changes/20250717_progress.md
+++ b/docs/changes/20250717_progress.md
@@ -5,4 +5,6 @@
 - Serializer/Deserializer キャッシュ実装とテストを追加
 ## 2025-07-17 21:42 JST [assistant]
 - Removed redundant SendError event wiring in KafkaProducerManager
+## 2025-07-17 22:23 JST [assistant]
+- Updated multiple design docs to clarify that Messaging layer performs Avro conversion and caches serializers/deserializers
 

--- a/docs/docs_configuration_reference.md
+++ b/docs/docs_configuration_reference.md
@@ -63,6 +63,11 @@ Kafka.Ksql.Linq では、`appsettings.json` を通じて柔軟なDSL設定が可
 
 ### 📦 1.2 Topics（トピックごとの詳細設定）
 
+Producer の設定は `Kafka.Ksql.Linq.Messaging.Configuration.ProducerSection`、
+Consumer の設定は `ConsumerSection` クラスにそれぞれマッピングされます。
+アプリ設定ファイルの項目名とクラスプロパティが 1 対 1 で対応するため、
+カスタム設定を追加する際はこれらのクラスを拡張してください。
+
 ```json
 "Topics": {
   "my-topic": {

--- a/docs/namespaces/messaging_namespace_doc.md
+++ b/docs/namespaces/messaging_namespace_doc.md
@@ -1,7 +1,7 @@
 # Kafka.Ksql.Linq.Messaging 責務ドキュメント
 
 ## 概要
-Kafka メッセージング機能の型安全な抽象化層を提供する namespace。Producer/Consumer の統一管理、設定管理、エラーハンドリング（DLQ）を担当。新アーキテクチャでは **key/value の送受信のみを担う最小 API** へ責務を絞る。
+Kafka メッセージング機能の型安全な抽象化層を提供する namespace。Producer/Consumer の統一管理、設定管理、エラーハンドリング（DLQ）を担当。POCO と key/value の変換には `Mapping` namespace の `PocoMapper` を利用し、Kafka との通信では Avro 形式を用いる。キー・値の Avro `Serializer`/`Deserializer` は内部でキャッシュし、KsqlContext からの送受信を効率化する。
 
 ## 主要な責務
 

--- a/docs/structure/amagi/key_value_flow_amagi.md
+++ b/docs/structure/amagi/key_value_flow_amagi.md
@@ -36,7 +36,7 @@ MappingManager の登録処理は KsqlContext 初期化と同時にまとめて�
 shared版で追加された [型情報・設計情報管理フロー](../shared/key_value_flow.md#8-%E5%9E%8B%E6%83%85%E5%A0%B1%E3%83%BB%E8%A8%AD%E8%A8%88%E6%83%85%E5%A0%B1%E7%AE%A1%E7%90%86%E3%83%95%E3%83%AD%E3%83%BC) を踏まえ、PM視点では次の点を管理指針とします。
 
 1. **PropertyMeta集中管理**: Fluent APIで確定した型情報を `PropertyMeta` として集約し、変更時はMappingManager経由でのみ更新する。
-2. **Messaging責務の純化**: key/valueのバイト列送受信に専念させ、設計変更の波及を避ける。
+2. **Messaging層の責務**: `KafkaProducerManager` と `KafkaConsumerManager` が POCO と key/value の Avro 変換を行う。生成した `Serializer`/`Deserializer` はキャッシュし、送受信性能を確保する。
 3. **設計進化時の通知**: 新規POCO追加や属性変更はMapping登録フローの更新を必須とし、進捗ログに記録する。
 
 この方針に沿って進捗管理・レビューを行います。

--- a/docs/structure/kyouka/key_value_flow_kyouka.md
+++ b/docs/structure/kyouka/key_value_flow_kyouka.md
@@ -40,5 +40,5 @@
 
 ### 型情報管理レビュー
 - `PropertyMeta` による型情報の集中管理を正式ルールとし、Mapping 以外の層で型定義を持たないことを確認。
-- Messaging 層はバイト列処理のみを担当し、Mapping 更新時の影響範囲を最小化する構造を維持する。
+- Messaging 層では `KafkaProducerManager` と `KafkaConsumerManager` が Avro 変換とキャッシュ処理を担う。Mapping 更新時の影響を最小化しつつ、送受信効率を保つ。
 - 新しい POCO 追加時は必ず MappingManager 登録フローが実行されているかを監査ポイントとする。

--- a/docs/structure/naruse/key_value_flow_naruse.md
+++ b/docs/structure/naruse/key_value_flow_naruse.md
@@ -78,4 +78,4 @@ await context.AddAsync(entity);
 sharedドキュメントの型情報管理フローを受け、実装担当として以下を意識します。
 1. `PropertyMeta` 定義は Fluent API で決定し、クラス属性には依存しない。
 2. `MappingManager` で自動生成される KeyType/ValueType を中心に型情報をやり取りする。
-3. Messaging 層には型を渡さず、バイト列のみでやり取りすることで実装の安定度を高める。
+3. Messaging 層では `KafkaProducerManager` / `KafkaConsumerManager` が POCO と key/value の Avro 変換を担当し、Serializer/Deserializer をキャッシュして安定した処理を実現する。

--- a/docs/structure/shared/key_value_flow.md
+++ b/docs/structure/shared/key_value_flow.md
@@ -165,12 +165,11 @@ await ctx.AddAsync(entity);
 - POCO⇄key/value⇄バイト列の流れで、型安全・設計一貫性を担保。
 - POCO⇄key/valueの変換は`KeyValueTypeMapping`提供のAPIを用い、POCO型へのリフレクションや独自探索を行わない。
 
-### 8.4 Messaging層の責務純化
-- Messaging は **バイト列 (keyBytes, valueBytes) とトピック名のみ** を扱う。POCO 型や PropertyMeta など設計情報への参照は一切持たない。
-- DLQ (Dead Letter Queue) も単なる送信先トピックとして扱い、特別な型やロジックを Messaging 層で実装しない。
-- DLQ 管理機能は Core 層で担い、Messaging 層はバイト列送受信のみを行う。
-- 型情報やスキーマ管理は Mapping/Serialization 層で完結させ、Messaging 層の API は `PublishAsync(byte[] keyBytes, byte[] valueBytes, string topic)` / `ConsumeAsync(string topic)` が基本形となる。
-- 型進化や属性追加は Mapping 更新だけで全体へ即反映され、Messaging 層の実装・運用は完全不変となる。
+### 8.4 Messaging層の責務
+- `KafkaProducerManager` と `KafkaConsumerManager` が `PocoMapper` を介して POCO と key/value の Avro 変換を行う。
+- `Serializer` と `Deserializer` は生成後にキャッシュされ、高頻度の送受信にも耐えられるよう最適化される。
+- DLQ (Dead Letter Queue) 送信は Messaging 経由で行うが、エンベロープ生成やポリシー判断は Core 層が担当する。
+- 型情報やスキーマ管理は Mapping/Serialization 層に集約し、Messaging 層はそれらを利用するだけのシンプルな構造を維持する。
 
 ### 8.5 設計進化時の運用ポイント
 - 新しいPOCOや属性、精度/フォーマットの追加もMappingへの登録・PropertyMeta反映だけでOK。
@@ -229,7 +228,7 @@ var (recvKeyBytes, recvValueBytes) = await messagingConsumer.ConsumeAsync(topic)
 ■ ポイント
 設計フロー・サンプルコードとも「PropertyMeta管理→Mapping→型生成→Avro変換→Messaging」の流れが“一本化”
 
-すべての型情報・設計情報はMappingで一元管理／Messagingは型意識せずバイト列のみ扱う
+すべての型情報・設計情報は Mapping が一元管理し、Messaging 層では `KafkaProducerManager` と `KafkaConsumerManager` が Avro 変換を行う
 
 
 

--- a/task/ksql_dsl_responsibilities.md
+++ b/task/ksql_dsl_responsibilities.md
@@ -257,9 +257,9 @@
 ### `KsqlDsl.Messaging.Consumers`
 
 #### `KafkaConsumerManager`
-- **責務**: 型安全Consumer管理
-- **役割**: Pool削除、直接管理、型安全性強化
-- **設計意図**: EF風API、事前確定管理
+- **責務**: 型安全Consumer管理、受信データの Avro → POCO 変換
+- **役割**: Pool削除、直接管理、型安全性強化、`PocoMapper` 経由のデシリアライズ
+- **設計意図**: EF風API、事前確定管理、Deserializer キャッシュによる性能向上
 - **拡張可否**: 可（Consumer機能拡張）
 
 #### `KafkaConsumer<TValue, TKey>`
@@ -271,9 +271,9 @@
 ### `KsqlDsl.Messaging.Producers`
 
 #### `KafkaProducerManager`
-- **責務**: 型安全Producer管理
-- **役割**: Pool削除、直接管理、型安全性強化
-- **設計意図**: EF風API、事前確定管理
+- **責務**: 型安全Producer管理、送信データの POCO → Avro 変換
+- **役割**: Pool削除、直接管理、型安全性強化、`PocoMapper` でキー生成
+- **設計意図**: EF風API、事前確定管理、Serializer キャッシュによる性能向上
 - **拡張可否**: 可（Producer機能拡張）
 
 #### `KafkaProducer<T>`


### PR DESCRIPTION
## Summary
- update messaging docs to clarify POCO↔Avro responsibilities
- document that appsettings `Producer`/`Consumer` sections map to `ProducerSection`/`ConsumerSection`
- implement serializer/deserializer caching in `KafkaProducerManager` and `KafkaConsumerManager`
- update responsibilities doc with new descriptions
- add tests verifying cache behavior
- remove redundant `SendError` event wiring
- record progress log

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6878e9b27b7c8327811b75a8bed4eb62