### PR TITLE
Replace Console.WriteLine with logger

### DIFF
--- a/docs/changes/20250731_progress.md
+++ b/docs/changes/20250731_progress.md
@@ -27,3 +27,6 @@
 - 不存在ファイルへの参照を修正し手動コミット文書リンクを整理
 ## 2025-07-18 01:13 JST [assistant]
 - translated Japanese comments to English in several configuration and error handling files
+## 2025-07-18 10:31 JST [assistant]
+- replaced Console.WriteLine with logger in TestEnvironment and KsqlContext
+- added logger usage for ErrorHandlingContext

--- a/src/KsqlContext.cs
+++ b/src/KsqlContext.cs
@@ -14,6 +14,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using ConfluentSchemaRegistry = Confluent.SchemaRegistry;
+using Microsoft.Extensions.Logging;
 
 namespace Kafka.Ksql.Linq.Application;
 /// <summary>
@@ -30,6 +31,7 @@ public abstract class KsqlContext : KafkaContextCore
     private readonly KafkaAdminService _adminService;
     private readonly KsqlDslOptions _dslOptions;
     private TableCacheRegistry? _cacheRegistry;
+    private static readonly ILogger Logger = LoggerFactory.Create(builder => builder.AddConsole()).CreateLogger<KsqlContext>();
 
     /// <summary>
     /// Hook to decide whether schema registration should be skipped for tests
@@ -150,7 +152,7 @@ public abstract class KsqlContext : KafkaContextCore
             await _adminService.EnsureWindowFinalTopicsExistAsync(GetEntityModels());
 
             // Log output: DLQ preparation complete
-            Console.WriteLine($"✅ Kafka initialization completed. DLQ topic '{GetDlqTopicName()}' is ready with 5-second retention.");
+            Logger.LogInformation("✅ Kafka initialization completed. DLQ topic '{Topic}' is ready with 5-second retention.", GetDlqTopicName());
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- switch Console.WriteLine statements to `ILogger`
- log warnings and errors with level-specific methods
- record progress update

## Testing
- `dotnet build -c Debug`
- `dotnet test --no-build -v q`

------
https://chatgpt.com/codex/tasks/task_e_6879a216fb2083278882f4eee440b8a8