### PR TITLE
Clarify query execution mode

### DIFF
--- a/docs/docs_advanced_rules.md
+++ b/docs/docs_advanced_rules.md
@@ -137,6 +137,7 @@ OSS本体はアプリケーション側の運用情報・エラー通知等を**
 
 - `GroupBy`, `Aggregate`, `Window` を含むLINQ式はテーブルと判定
 - `AsStream()`, `AsTable()` は判定ロジックを上書き
+- `AsPush()`, `AsPull()` でクエリの実行モードを強制（未指定時は `Unspecified` として扱い、Pull クエリ制約違反検知時に自動で Push へ切り替え）
 - 判定結果は `.Explain()` や `ILogger` に出力可能（開発支援）
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -196,6 +196,8 @@ public class MyKsqlContext : KsqlContext
 
 これらのメソッドは呼び出された場合に NotSupportedException をスローする設計とし、誤用を防止する。
 
+### Push/Pull Query の明示
+`DefineQuery` で使用するクエリビルダーは `.AsPush()` / `.AsPull()` により実行モードを指定できます。明示しない場合は `Unspecified` 扱いとなり、Schema Registry 登録時に Pull クエリの制約違反が検出されると自動で Push (`EMIT CHANGES` 付き) へ切り替わります。
 ※その他の詳細設定はdev_guide.md参照
 
 ## 4. スキーマ構築と初期化手順（OnModelCreating）

--- a/src/Core/Modeling/entity-builder-extensions.cs
+++ b/src/Core/Modeling/entity-builder-extensions.cs
@@ -160,7 +160,8 @@ public static class EntityBuilderQueryExtensions
             $"Target={schema.TargetType.FullName}," +
             $"KeyClass={schema.KeyInfo.ClassName},KeyNs={schema.KeyInfo.Namespace}," +
             $"ValueClass={schema.ValueInfo.ClassName},ValueNs={schema.ValueInfo.Namespace}," +
-            $"Keys={schema.KeyProperties.Length},Type={schema.GetStreamTableType()}";
+            $"Keys={schema.KeyProperties.Length},Type={schema.GetStreamTableType()}," +
+            $"Mode={schema.ExecutionMode}";
         
         entityModel.ValidationResult.Warnings.Add(schemaInfo);
     }

--- a/src/Query/Pipeline/QueryExecutionMode.cs
+++ b/src/Query/Pipeline/QueryExecutionMode.cs
@@ -3,8 +3,12 @@ namespace Kafka.Ksql.Linq.Query.Pipeline;
 /// クエリ実行モード
 /// 設計理由：Pull Query（一回限り）とPush Query（ストリーミング）の区別
 /// </summary>
-internal enum QueryExecutionMode
+public enum QueryExecutionMode
 {
+    /// <summary>
+    /// Execution mode not explicitly specified.
+    /// </summary>
+    Unspecified,
     /// <summary>
     /// Pull Query - 一回限りのクエリ実行
     /// </summary>

--- a/src/Query/Schema/QuerySchema.cs
+++ b/src/Query/Schema/QuerySchema.cs
@@ -1,4 +1,5 @@
 using Kafka.Ksql.Linq.Core.Models;
+using Kafka.Ksql.Linq.Query.Pipeline;
 using System;
 using System.Collections.Generic;
 
@@ -13,6 +14,10 @@ public class QuerySchema
     public string TopicName { get; set; } = string.Empty;
     public bool IsValid { get; set; }
     public List<string> Errors { get; set; } = new();
+    /// <summary>
+    /// Query execution mode. <see cref="QueryExecutionMode.Unspecified"/> if not explicitly configured.
+    /// </summary>
+    public QueryExecutionMode ExecutionMode { get; set; } = QueryExecutionMode.Unspecified;
 
     public PropertyMeta[] KeyProperties
     {


### PR DESCRIPTION
## Summary
- extend `QueryExecutionMode` with `Unspecified` value
- default `QuerySchema.ExecutionMode` to `Unspecified`
- mention automatic push fallback in docs
- ensure `KsqlContextPropertyProvider.cs` ends with a newline

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj -v minimal`
- `dotnet test physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj --no-build --filter Category=Integration`

------
https://chatgpt.com/codex/tasks/task_e_6879cc6963108327aa9555bcda3b1382