### PR TITLE
Fix producer serializers and support decimal SUM

### DIFF
--- a/docs/changes/20250726_progress.md
+++ b/docs/changes/20250726_progress.md
@@ -2,3 +2,5 @@
 - Fluent API サンプルを `src/Entities/Samples` 配下へ移動
 - `AddSampleModels` でモデル登録が遅延しないよう DI 登録方法を修正
 - 既存テストをサンプルの新配置に合わせて確認
+## 2025-07-18 19:03 JST [shion]
+- physicalTests failing due to missing serializers and decimal SUM support. Implemented serializers in KafkaProducerManager and added DECIMAL support for SUM/AVG in function translator.

--- a/src/Messaging/Producers/KafkaProducerManager.cs
+++ b/src/Messaging/Producers/KafkaProducerManager.cs
@@ -68,15 +68,17 @@ internal class KafkaProducerManager : IDisposable
             var entityModel = GetEntityModel<T>();
             var topicName = (entityModel.TopicName ?? entityType.Name).ToLowerInvariant();
 
-            // Confluent.Kafka Producer作成
-            var config = BuildProducerConfig(topicName);
-            var rawProducer = new ProducerBuilder<object, object>(config).Build();
-
             // Serializer creation via Confluent factory
             var keyType = KeyExtractor.DetermineKeyType(entityModel);
             var keySerializer = CreateKeySerializer(keyType);
-
             var valueSerializer = GetValueSerializer<T>();
+
+            // Confluent.Kafka Producer作成 with serializers
+            var config = BuildProducerConfig(topicName);
+            var rawProducer = new ProducerBuilder<object, object>(config)
+                .SetKeySerializer(keySerializer)
+                .SetValueSerializer(valueSerializer)
+                .Build();
 
             var producer = new KafkaProducer<T>(
                 rawProducer,
@@ -109,13 +111,15 @@ internal class KafkaProducerManager : IDisposable
 
         var entityModel = GetEntityModel<T>();
 
-        var config = BuildProducerConfig(topicName);
-        var rawProducer = new ProducerBuilder<object, object>(config).Build();
-
         var keyType = KeyExtractor.DetermineKeyType(entityModel);
         var keySerializer = CreateKeySerializer(keyType);
-
         var valueSerializer = GetValueSerializer<T>();
+
+        var config = BuildProducerConfig(topicName);
+        var rawProducer = new ProducerBuilder<object, object>(config)
+            .SetKeySerializer(keySerializer)
+            .SetValueSerializer(valueSerializer)
+            .Build();
 
         var producer = new KafkaProducer<T>(
             rawProducer,

--- a/src/Query/Builders/Functions/KsqlFunctionTranslator.cs
+++ b/src/Query/Builders/Functions/KsqlFunctionTranslator.cs
@@ -14,8 +14,8 @@ internal static class KsqlFunctionTranslator
 {
     private static readonly Dictionary<string, HashSet<string>> _functionTypeMatrix = new()
     {
-        ["SUM"] = new(["INT", "BIGINT", "DOUBLE"]),
-        ["AVG"] = new(["INT", "BIGINT", "DOUBLE"]),
+        ["SUM"] = new(["INT", "BIGINT", "DOUBLE", "DECIMAL"]),
+        ["AVG"] = new(["INT", "BIGINT", "DOUBLE", "DECIMAL"]),
         ["MIN"] = new(["INT", "BIGINT", "DOUBLE", "DECIMAL", "STRING", "BOOLEAN", "DATETIME"]),
         ["MAX"] = new(["INT", "BIGINT", "DOUBLE", "DECIMAL", "STRING", "BOOLEAN", "DATETIME"]),
         ["COUNT"] = new(["INT", "BIGINT", "DOUBLE", "DECIMAL", "STRING", "BOOLEAN", "DATETIME", "STRUCT"]),

--- a/tests/Query/Builders/Functions/KsqlFunctionTranslatorTests.cs
+++ b/tests/Query/Builders/Functions/KsqlFunctionTranslatorTests.cs
@@ -144,11 +144,12 @@ public class KsqlFunctionTranslatorTests
     }
 
     [Fact]
-    public void Translate_Sum_WithDecimal_Throws()
+    public void Translate_Sum_WithDecimal_ReturnsSum()
     {
         Expression<Func<Entity, object>> expr = e => Sum(e.Amount);
         var call = GetCall(expr);
-        Assert.Throws<NotSupportedException>(() => KsqlFunctionTranslator.TranslateMethodCall(call));
+        var result = KsqlFunctionTranslator.TranslateMethodCall(call);
+        Assert.Equal("SUM(Amount)", result);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- ensure `KafkaProducerManager` provides serializers when building `ProducerBuilder`
- allow decimal arguments for SUM/AVG in `KsqlFunctionTranslator`
- update translator test accordingly
- log today's progress

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj -v minimal`
- `dotnet test physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj --filter Category=Integration`

------
https://chatgpt.com/codex/tasks/task_e_687a1b3ae3608327af480effcc7d064b