### PR TITLE
Fix Kafka producer serializers and revert decimal SUM

### DIFF
--- a/src/Messaging/Producers/KafkaProducerManager.cs
+++ b/src/Messaging/Producers/KafkaProducerManager.cs
@@ -70,13 +70,17 @@ internal class KafkaProducerManager : IDisposable
 
             // Confluent.Kafka Producer作成
             var config = BuildProducerConfig(topicName);
-            var rawProducer = new ProducerBuilder<object, object>(config).Build();
 
             // Serializer creation via Confluent factory
             var keyType = KeyExtractor.DetermineKeyType(entityModel);
             var keySerializer = CreateKeySerializer(keyType);
 
             var valueSerializer = GetValueSerializer<T>();
+
+            var rawProducer = new ProducerBuilder<object, object>(config)
+                .SetKeySerializer(keySerializer)
+                .SetValueSerializer(valueSerializer)
+                .Build();
 
             var producer = new KafkaProducer<T>(
                 rawProducer,
@@ -110,12 +114,16 @@ internal class KafkaProducerManager : IDisposable
         var entityModel = GetEntityModel<T>();
 
         var config = BuildProducerConfig(topicName);
-        var rawProducer = new ProducerBuilder<object, object>(config).Build();
 
         var keyType = KeyExtractor.DetermineKeyType(entityModel);
         var keySerializer = CreateKeySerializer(keyType);
 
         var valueSerializer = GetValueSerializer<T>();
+
+        var rawProducer = new ProducerBuilder<object, object>(config)
+            .SetKeySerializer(keySerializer)
+            .SetValueSerializer(valueSerializer)
+            .Build();
 
         var producer = new KafkaProducer<T>(
             rawProducer,


### PR DESCRIPTION
## Summary
- ensure key and value serializers are specified when building Kafka producers
- support basic JOIN handling in DDL query generator
- revert decimal support for SUM in function translator
- expect NotSupportedException in decimal SUM test

## Testing
- `dotnet test Kafka.Ksql.Linq.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_687a3b0e03ac83279baa7751bb6502a5