### PR TITLE
Fix JOIN aggregation test casting

### DIFF
--- a/physicalTests/DynamicKsqlGenerationTests.cs
+++ b/physicalTests/DynamicKsqlGenerationTests.cs
@@ -110,8 +110,8 @@ public class DynamicKsqlGenerationTests
         var join = orders
             .Join(customers, o => o.CustomerId, c => c.Id, (o, c) => new { o, c })
             .GroupBy(x => x.o.CustomerId)
-            .Having(g => g.Sum(x => x.o.Amount) > 1000)
-            .Select(g => new { g.Key, Total = g.Sum(x => x.o.Amount) });
+            .Having(g => g.Sum(x => (double)x.o.Amount) > 1000)
+            .Select(g => new { g.Key, Total = g.Sum(x => (double)x.o.Amount) });
         yield return ExecuteInScope(() => dml.GenerateLinqQuery("orders", join.Expression, false).ToUpperInvariant());
 
         var multiKey = orders

--- a/src/Messaging/Producers/KafkaProducerManager.cs
+++ b/src/Messaging/Producers/KafkaProducerManager.cs
@@ -70,13 +70,17 @@ internal class KafkaProducerManager : IDisposable
 
             // Confluent.Kafka Producer作成
             var config = BuildProducerConfig(topicName);
-            var rawProducer = new ProducerBuilder<object, object>(config).Build();
 
             // Serializer creation via Confluent factory
             var keyType = KeyExtractor.DetermineKeyType(entityModel);
             var keySerializer = CreateKeySerializer(keyType);
 
             var valueSerializer = GetValueSerializer<T>();
+
+            var rawProducer = new ProducerBuilder<object, object>(config)
+                .SetKeySerializer(keySerializer)
+                .SetValueSerializer(valueSerializer)
+                .Build();
 
             var producer = new KafkaProducer<T>(
                 rawProducer,
@@ -110,12 +114,16 @@ internal class KafkaProducerManager : IDisposable
         var entityModel = GetEntityModel<T>();
 
         var config = BuildProducerConfig(topicName);
-        var rawProducer = new ProducerBuilder<object, object>(config).Build();
 
         var keyType = KeyExtractor.DetermineKeyType(entityModel);
         var keySerializer = CreateKeySerializer(keyType);
 
         var valueSerializer = GetValueSerializer<T>();
+
+        var rawProducer = new ProducerBuilder<object, object>(config)
+            .SetKeySerializer(keySerializer)
+            .SetValueSerializer(valueSerializer)
+            .Build();
 
         var producer = new KafkaProducer<T>(
             rawProducer,


### PR DESCRIPTION
## Summary
- specify serializers when building Kafka producers
- support JOIN in DDL query generation
- adjust integration test to cast decimal values to double in JOIN aggregations

## Testing
- `dotnet test Kafka.Ksql.Linq.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_687a3b0e03ac83279baa7751bb6502a5