### PR TITLE
Simplify context creation from appsettings

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ C#のLINQスタイルで簡潔かつ直感的に記述できる、Entity Framewo
 ```
 using Kafka.Ksql.Linq.Application;
 using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Context;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using System;
@@ -52,11 +53,8 @@ class Program
             .AddJsonFile("appsettings.json")
             .Build();
 
-        var context = KsqlContextBuilder.Create()
-            .UseConfiguration(configuration)
-            .UseSchemaRegistry(configuration["KsqlDsl:SchemaRegistry:Url"]!)
-            .EnableLogging(LoggerFactory.Create(builder => builder.AddConsole()))
-            .BuildContext<ManualCommitContext>();
+        var options = KafkaContextOptions.FromConfiguration(configuration);
+        await using var context = new ManualCommitContext(options);
 
         var order = new ManualCommitOrder
         {

--- a/docs/changes/20250731_progress.md
+++ b/docs/changes/20250731_progress.md
@@ -53,3 +53,6 @@
 ## 2025-07-19 08:31 JST [assistant]
 - fixed daily-comparison sample to load full configuration from appsettings.json via KsqlContextBuilder
 - updated docs accordingly
+## 2025-07-19 08:46 JST [assistant]
+- simplified context creation via KafkaContextOptions.FromAppSettings
+- updated README and sample programs accordingly

--- a/examples/daily-comparison/ComparisonViewer/Program.cs
+++ b/examples/daily-comparison/ComparisonViewer/Program.cs
@@ -1,23 +1,7 @@
 using DailyComparisonLib;
 using DailyComparisonLib.Models;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 
-var configuration = new ConfigurationBuilder()
-    .AddJsonFile("appsettings.json")
-    .Build();
-
-var loggerFactory = LoggerFactory.Create(b =>
-{
-    b.AddConfiguration(configuration.GetSection("Logging"));
-    b.AddConsole();
-});
-
-await using var context = KsqlContextBuilder.Create()
-    .UseConfiguration(configuration)
-    .UseSchemaRegistry(configuration["KsqlDsl:SchemaRegistry:Url"]!)
-    .EnableLogging(loggerFactory)
-    .BuildContext<MyKsqlContext>();
+await using var context = MyKsqlContext.FromAppSettings("appsettings.json");
 
 var comparisons = await context.Set<DailyComparison>().ToListAsync();
 

--- a/examples/daily-comparison/DailyComparisonLib/KafkaKsqlContext.cs
+++ b/examples/daily-comparison/DailyComparisonLib/KafkaKsqlContext.cs
@@ -7,11 +7,7 @@ namespace DailyComparisonLib;
 
 public class KafkaKsqlContext : KafkaContext
 {
-    public KafkaKsqlContext()
-    {
-    }
-
-    public KafkaKsqlContext(KsqlContextOptions options) : base(options)
+    public KafkaKsqlContext(KafkaContextOptions options) : base(options)
     {
     }
 

--- a/examples/daily-comparison/DailyComparisonLib/MyKsqlContext.cs
+++ b/examples/daily-comparison/DailyComparisonLib/MyKsqlContext.cs
@@ -1,10 +1,24 @@
 using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq.Core.Context;
+using Microsoft.Extensions.Configuration;
 
 namespace DailyComparisonLib;
 
 public class MyKsqlContext : KafkaKsqlContext
 {
-    public MyKsqlContext(KsqlContextOptions options) : base(options)
+    public MyKsqlContext(KafkaContextOptions options) : base(options)
     {
+    }
+
+    public static MyKsqlContext FromConfiguration(IConfiguration configuration)
+    {
+        var options = KafkaContextOptions.FromConfiguration(configuration);
+        return new MyKsqlContext(options);
+    }
+
+    public static MyKsqlContext FromAppSettings(string path)
+    {
+        var options = KafkaContextOptions.FromAppSettings(path);
+        return new MyKsqlContext(options);
     }
 }

--- a/examples/daily-comparison/README.md
+++ b/examples/daily-comparison/README.md
@@ -3,7 +3,7 @@
 This example demonstrates a simple rate ingestion and daily aggregation using **Kafka.Ksql.Linq** only.
 All settings including logging and Schema Registry configuration are read from
 `appsettings.json` following `docs/docs_configuration_reference.md`.
-`KsqlContextBuilder` builds a `MyKsqlContext` using these values.
+`MyKsqlContext.FromAppSettings()` builds the context directly from this file.
 
 ## Usage
 
@@ -11,7 +11,7 @@ All settings including logging and Schema Registry configuration are read from
    ```bash
    docker compose up -d
    ```
-2. Run the rate sender which also performs aggregation. It uses `KsqlContextBuilder` to create `MyKsqlContext`:
+2. Run the rate sender which also performs aggregation. It uses `MyKsqlContext.FromAppSettings()`:
    ```bash
    dotnet run --project RateSender
    ```

--- a/examples/daily-comparison/RateSender/Program.cs
+++ b/examples/daily-comparison/RateSender/Program.cs
@@ -1,23 +1,7 @@
 using DailyComparisonLib;
 using DailyComparisonLib.Models;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 
-var configuration = new ConfigurationBuilder()
-    .AddJsonFile("appsettings.json")
-    .Build();
-
-var loggerFactory = LoggerFactory.Create(b =>
-{
-    b.AddConfiguration(configuration.GetSection("Logging"));
-    b.AddConsole();
-});
-
-await using var context = KsqlContextBuilder.Create()
-    .UseConfiguration(configuration)
-    .UseSchemaRegistry(configuration["KsqlDsl:SchemaRegistry:Url"]!)
-    .EnableLogging(loggerFactory)
-    .BuildContext<MyKsqlContext>();
+await using var context = MyKsqlContext.FromAppSettings("appsettings.json");
 
 var broker = "demo";
 var symbol = "EURUSD";

--- a/examples/daily-comparison/tests/AggregatorTests.cs
+++ b/examples/daily-comparison/tests/AggregatorTests.cs
@@ -2,6 +2,7 @@ using DailyComparisonLib;
 using DailyComparisonLib.Models;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Modeling;
+using Kafka.Ksql.Linq.Core.Context;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -86,7 +87,7 @@ public class AggregatorTests
     private class KafkaKsqlContextStub : KafkaKsqlContext
     {
         private readonly IKsqlContext _inner;
-        public KafkaKsqlContextStub(IKsqlContext inner) { _inner = inner; }
+        public KafkaKsqlContextStub(IKsqlContext inner) : base(new KafkaContextOptions()) { _inner = inner; }
         protected override bool SkipSchemaRegistration => true;
         protected override IEntitySet<T> CreateEntitySet<T>(EntityModel entityModel) where T : class
         {

--- a/src/Core/Context/KafkaContextOptions.cs
+++ b/src/Core/Context/KafkaContextOptions.cs
@@ -1,10 +1,23 @@
-﻿using Kafka.Ksql.Linq.Configuration;
+using Kafka.Ksql.Linq.Configuration;
+using Microsoft.Extensions.Configuration;
 
 namespace Kafka.Ksql.Linq.Core.Context;
 
 public class KafkaContextOptions
 {
-
     public ValidationMode ValidationMode { get; set; } = ValidationMode.Strict;
 
+    public IConfiguration? Configuration { get; set; }
+
+    public static KafkaContextOptions FromConfiguration(IConfiguration configuration)
+    {
+        return new KafkaContextOptions { Configuration = configuration };
+    }
+
+    public static KafkaContextOptions FromAppSettings(string path)
+    {
+        var configuration = new ConfigurationBuilder().AddJsonFile(path).Build();
+        return FromConfiguration(configuration);
+    }
 }
+

--- a/src/Kafka.Ksql.Linq.csproj
+++ b/src/Kafka.Ksql.Linq.csproj
@@ -28,6 +28,7 @@
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="8.0.17" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />


### PR DESCRIPTION
## Summary
- add `FromConfiguration` and `FromAppSettings` factory methods to `KafkaContextOptions`
- expose helper constructors in `MyKsqlContext`
- remove builder usage from daily-comparison programs
- document new workflow in README files
- fix tests for new constructor

## Testing
- `dotnet test examples/daily-comparison/tests/DailyComparisonLib.Tests.csproj --verbosity minimal`
- `dotnet test physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj --filter Category=Integration --verbosity minimal` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_687adaecad748327acaca14cf3a87e78