### PR TITLE
Update daily comparison implementation

### DIFF
--- a/docs/changes/20250719_progress.md
+++ b/docs/changes/20250719_progress.md
@@ -21,3 +21,13 @@
 - スケジュール範囲指定を `BaseOn` パラメータで受け取るよう変更
 - `HasScheduleRange` API を撤廃しドキュメントを更新
 
+
+## 2025-07-19 02:11 JST [assistant]
+- daily_comparison/instruction.md に ScheduleRange を利用した足生成方針を追記。1分・5分・60分足も生成対象に追加
+## 2025-07-19 11:41 JST [assistant]
+- implemented schedule-range based aggregation for daily comparison and added rate candle generation for 1,5,60 minute bars
+
+## 2025-07-19 02:53 JST [assistant]
+- Reviewed inline comments and removed redundant filtering in Aggregator
+- Documented primary key note for RateCandle
+

--- a/examples/daily-comparison/DailyComparisonLib/Aggregator.cs
+++ b/examples/daily-comparison/DailyComparisonLib/Aggregator.cs
@@ -1,5 +1,6 @@
 using DailyComparisonLib.Models;
 using Kafka.Ksql.Linq;
+using System.Linq;
 
 namespace DailyComparisonLib;
 
@@ -11,6 +12,12 @@ public class Aggregator
         _context = context;
     }
 
+    private static DateTime FloorToMinutes(DateTime timestamp, int minutes)
+    {
+        var ticks = TimeSpan.FromMinutes(minutes).Ticks;
+        return new DateTime(timestamp.Ticks - (timestamp.Ticks % ticks), timestamp.Kind);
+    }
+
     public async Task AggregateAsync(DateTime date, CancellationToken ct = default)
     {
         var schedules = (await _context.Set<MarketSchedule>().ToListAsync(ct))
@@ -19,10 +26,10 @@ public class Aggregator
 
         foreach (var schedule in schedules)
         {
-            var rates = (await _context.Set<Rate>().ToListAsync(ct))
+            var rates = await _context.Set<Rate>()
                 .Where(r => r.Broker == schedule.Broker && r.Symbol == schedule.Symbol)
-                .Where(r => r.RateTimestamp >= schedule.OpenTime && r.RateTimestamp <= schedule.CloseTime)
-                .ToList();
+                .Window().BaseOn<MarketSchedule>(r => r.Symbol, nameof(MarketSchedule.OpenTime), nameof(MarketSchedule.CloseTime))
+                .ToListAsync(ct);
 
             if (rates.Count == 0) continue;
 
@@ -47,6 +54,33 @@ public class Aggregator
                 PrevClose = prevClose,
                 Diff = diff
             }, ct);
+
+            foreach (var minutes in new[] { 1, 5, 60 })
+            {
+                // TODO: This manual grouping should be replaced with the
+                // built-in Window() aggregation once documentation is clarified.
+                var grouped = rates.GroupBy(r => FloorToMinutes(r.RateTimestamp, minutes));
+                foreach (var g in grouped)
+                {
+                    var open = g.OrderBy(r => r.RateTimestamp).First().Ask;
+                    var highM = g.Max(r => r.Ask);
+                    var lowM = g.Min(r => r.Bid);
+                    var closeM = g.OrderByDescending(r => r.RateTimestamp).First().Ask;
+
+                    await _context.Set<RateCandle>().AddAsync(new RateCandle
+                    {
+                        Broker = schedule.Broker,
+                        Symbol = schedule.Symbol,
+                        WindowStart = g.Key,
+                        WindowEnd = g.Key.AddMinutes(minutes),
+                        WindowMinutes = minutes,
+                        Open = open,
+                        High = highM,
+                        Low = lowM,
+                        Close = closeM
+                    }, ct);
+                }
+            }
         }
 
     }

--- a/examples/daily-comparison/DailyComparisonLib/KafkaKsqlContext.cs
+++ b/examples/daily-comparison/DailyComparisonLib/KafkaKsqlContext.cs
@@ -16,5 +16,6 @@ public class KafkaKsqlContext : KafkaContext
         modelBuilder.Entity<Rate>();
         modelBuilder.Entity<MarketSchedule>();
         modelBuilder.Entity<DailyComparison>();
+        modelBuilder.Entity<RateCandle>();
     }
 }

--- a/examples/daily-comparison/DailyComparisonLib/MarketSchedule.cs
+++ b/examples/daily-comparison/DailyComparisonLib/MarketSchedule.cs
@@ -1,5 +1,8 @@
+using Kafka.Ksql.Linq.Core.Attributes;
+
 namespace DailyComparisonLib.Models;
 
+[ScheduleRange(nameof(OpenTime), nameof(CloseTime))]
 public class MarketSchedule
 {
     public string Broker { get; set; } = null!;

--- a/examples/daily-comparison/DailyComparisonLib/RateCandle.cs
+++ b/examples/daily-comparison/DailyComparisonLib/RateCandle.cs
@@ -1,0 +1,15 @@
+namespace DailyComparisonLib.Models;
+
+public class RateCandle
+{
+    // Broker and Symbol form the composite primary key so they must not be null.
+    public string Broker { get; set; } = null!;
+    public string Symbol { get; set; } = null!;
+    public DateTime WindowStart { get; set; }
+    public DateTime WindowEnd { get; set; }
+    public int WindowMinutes { get; set; }
+    public decimal Open { get; set; }
+    public decimal High { get; set; }
+    public decimal Low { get; set; }
+    public decimal Close { get; set; }
+}

--- a/examples/daily-comparison/tests/AggregatorTests.cs
+++ b/examples/daily-comparison/tests/AggregatorTests.cs
@@ -66,9 +66,11 @@ public class AggregatorTests
         var rateSet = new DummySet<Rate>(context);
         var scheduleSet = new DummySet<MarketSchedule>(context);
         var dailySet = new DummySet<DailyComparison>(context);
+        var candleSet = new DummySet<RateCandle>(context);
         context.AddSet(rateSet);
         context.AddSet(scheduleSet);
         context.AddSet(dailySet);
+        context.AddSet(candleSet);
 
         rateSet.AddItem(new Rate { Broker = "b", Symbol = "s", RateId = 1, RateTimestamp = new DateTime(2024,1,1,1,0,0), Bid = 1m, Ask = 1.1m });
         rateSet.AddItem(new Rate { Broker = "b", Symbol = "s", RateId = 2, RateTimestamp = new DateTime(2024,1,1,2,0,0), Bid = 2m, Ask = 2.1m });
@@ -82,6 +84,8 @@ public class AggregatorTests
         Assert.Equal(1m, result.Low);
         Assert.Equal(2.1m, result.Close);
         Assert.Equal(0m, result.Diff);
+
+        Assert.Equal(6, candleSet.ToListAsync().Result.Count);
     }
 
     private class KafkaKsqlContextStub : KafkaKsqlContext

--- a/features/daily_comparison/instruction.md
+++ b/features/daily_comparison/instruction.md
@@ -53,3 +53,7 @@ broker, symbol, date, high, low, close, prev_close, diff
 - marketscheduleが日次で自動更新される
 - 日足比較表が日次で自動生成される
 - 参照プロセスから比較表を任意タイミングで閲覧できる
+
+## 2025-07-19 02:11 JST [assistant]
+- ScheduleRange の条件を用いて DailyComparison の日足を計算する方法を明文化してください。具体的には `Window().BaseOn<TSchedule>()` でスケジュールテーブルを参照し、IF 条件で `openTime <= RateTimestamp < closeTime` を適用します。
+- 上記の処理を応用し、1分足、5分足、60分足の集計も同時に生成すること。必要に応じて `ScheduleRange` の範囲を分解して各分足を計算してください。


### PR DESCRIPTION
## Summary
- annotate `MarketSchedule` with `[ScheduleRange]`
- compute daily and minute bars in `Aggregator`
- add `RateCandle` entity and register in context
- test coverage for minute bar generation
- log progress for July 19
- address inline comments about schedule filtering and PK documentation

## Testing
- `dotnet test physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj --filter Category=Integration`

------
https://chatgpt.com/codex/tasks/task_e_687afe5db9f88327a313cea3f95ba620