### PR TITLE
Move window builder extension to core

### DIFF
--- a/docs/changes/20250731_progress.md
+++ b/docs/changes/20250731_progress.md
@@ -56,3 +56,11 @@
 ## 2025-07-19 08:46 JST [assistant]
 - simplified context creation via KafkaContextOptions.FromAppSettings
 - updated README and sample programs accordingly
+## 2025-07-19 13:44 JST [assistant]
+- moved ModelBuilderWindowExtensions to src/Core/Modeling and updated namespace
+- recorded change in diff_log/diff_window_extension_core_20250719.md
+
+
+## 2025-07-19 13:55 JST [assistant]
+- moved WindowDslExtensions into src/Core/Modeling folder as part of library core
+- verified build and tests

--- a/docs/diff_log/diff_window_extension_core_20250719.md
+++ b/docs/diff_log/diff_window_extension_core_20250719.md
@@ -1,0 +1,18 @@
+# 差分履歴: window_extension_core
+
+🗕 2025年7月19日（JST）
+🧐 作業者: codex
+
+## 差分タイトル
+ModelBuilderWindowExtensions を OSS 本体へ移動
+
+## 変更理由
+Window DSL をサンプルだけでなくライブラリ本体で利用可能にするため。
+
+## 追加・修正内容（反映先: oss_design_combined.md）
+- `examples/daily-comparison/DailyComparisonLib/ModelBuilderWindowExtensions.cs` を `src/Core/Modeling/` 配下に移動
+- 名前空間を `Kafka.Ksql.Linq.Core.Modeling` に変更
+- サンプル `KafkaKsqlContext` から新しい名前空間を参照
+
+## 参考文書
+- `docs/diff_log/diff_daily_comparison_extensionmove_20250719.md`

--- a/examples/daily-comparison/DailyComparisonLib/KafkaKsqlContext.cs
+++ b/examples/daily-comparison/DailyComparisonLib/KafkaKsqlContext.cs
@@ -1,7 +1,7 @@
 using Kafka.Ksql.Linq.Application;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Context;
-using Kafka.Ksql.Linq;
+using Kafka.Ksql.Linq.Core.Modeling;
 using DailyComparisonLib.Models;
 
 namespace DailyComparisonLib;

--- a/src/Core/Modeling/ModelBuilderWindowExtensions.cs
+++ b/src/Core/Modeling/ModelBuilderWindowExtensions.cs
@@ -3,7 +3,7 @@ using Kafka.Ksql.Linq.Core.Abstractions;
 using System.Linq;
 using System.Linq.Expressions;
 
-namespace Kafka.Ksql.Linq;
+namespace Kafka.Ksql.Linq.Core.Modeling;
 
 public static class WindowDslExtensions
 {


### PR DESCRIPTION
## Summary
- move `ModelBuilderWindowExtensions` from the daily comparison sample into the library core
- update `KafkaKsqlContext` to use the new namespace
- document the change in progress and diff logs

## Testing
- `dotnet test Kafka.Ksql.Linq.sln`


------
https://chatgpt.com/codex/tasks/task_e_687b2180ced0832783c06187297296ff