### PR TITLE
Implement Window filter for bar sets

### DIFF
--- a/docs/changes/20250719_progress.md
+++ b/docs/changes/20250719_progress.md
@@ -48,3 +48,7 @@
 ## 2025-07-19 13:35 JST [assistant]
 - reverted ModelBuilderWindowExtensions move; file stays in examples until finalized
 
+## 2025-07-19 14:52 JST [assistant]
+- Implemented Window(x) filter for bar entities with new WindowFilteredEntitySet and extension.
+- Added unit test verifying filtering.
+

--- a/docs/diff_log/diff_windowfilter_20250719.md
+++ b/docs/diff_log/diff_windowfilter_20250719.md
@@ -1,0 +1,18 @@
+# 差分履歴: windowfilter
+
+🗕 2025-07-19
+🧐 作業者: assistant
+
+## 差分タイトル
+Window() 拡張でバー集合をウィンドウ幅で絞り込み
+
+## 変更理由
+ユーザからの要望で、Set<T>().Window(x) 呼び出し時に指定幅のバーのみ取得できるようにするため。
+
+## 追加・修正内容（反映先: oss_design_combined.md）
+- WindowFilteredEntitySet を新規追加し、WindowMinutes でのフィルタ処理を実装
+- IEntitySet 拡張 Window(x) を追加
+- 単体テスト WindowFilterExtensionsTests を作成
+
+## 参考文書
+- docs_advanced_rules.md B.1.2

--- a/src/Core/Extensions/WindowFilterExtensions.cs
+++ b/src/Core/Extensions/WindowFilterExtensions.cs
@@ -1,0 +1,17 @@
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Window;
+using System;
+
+namespace Kafka.Ksql.Linq.Core.Extensions;
+
+public static class WindowFilterExtensions
+{
+    /// <summary>
+    /// Filter an entity set by its WindowMinutes property.
+    /// </summary>
+    public static IEntitySet<T> Window<T>(this IEntitySet<T> entitySet, int windowMinutes) where T : class
+    {
+        if (entitySet == null) throw new ArgumentNullException(nameof(entitySet));
+        return new WindowFilteredEntitySet<T>(entitySet, windowMinutes);
+    }
+}

--- a/src/Core/Window/WindowFilteredEntitySet.cs
+++ b/src/Core/Window/WindowFilteredEntitySet.cs
@@ -1,0 +1,65 @@
+using Kafka.Ksql.Linq.Core.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kafka.Ksql.Linq.Core.Window;
+
+internal class WindowFilteredEntitySet<T> : IEntitySet<T> where T : class
+{
+    private readonly IEntitySet<T> _baseSet;
+    private readonly int _windowMinutes;
+    private readonly PropertyInfo _windowProp;
+
+    internal WindowFilteredEntitySet(IEntitySet<T> baseSet, int windowMinutes)
+    {
+        _baseSet = baseSet ?? throw new ArgumentNullException(nameof(baseSet));
+        if (windowMinutes <= 0)
+            throw new ArgumentException("Window minutes must be positive", nameof(windowMinutes));
+        _windowMinutes = windowMinutes;
+
+        _windowProp = baseSet.GetEntityModel().AllProperties
+            .FirstOrDefault(p => p.Name == "WindowMinutes" &&
+                                 (p.PropertyType == typeof(int) || p.PropertyType == typeof(int?)))
+            ?? throw new InvalidOperationException($"Entity {typeof(T).Name} does not contain WindowMinutes property");
+    }
+
+    private bool Matches(T entity)
+    {
+        var value = _windowProp.GetValue(entity);
+        if (value == null) return false;
+        return Convert.ToInt32(value) == _windowMinutes;
+    }
+
+    public async Task<List<T>> ToListAsync(CancellationToken cancellationToken = default)
+    {
+        var all = await _baseSet.ToListAsync(cancellationToken);
+        return all.Where(Matches).ToList();
+    }
+
+    public async Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default)
+    {
+        await _baseSet.ForEachAsync(async e =>
+        {
+            if (Matches(e))
+                await action(e);
+        }, timeout, cancellationToken);
+    }
+
+    public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+    {
+        await foreach (var item in _baseSet.WithCancellation(cancellationToken))
+        {
+            if (Matches(item))
+                yield return item;
+        }
+    }
+
+    public Task AddAsync(T entity, CancellationToken cancellationToken = default) => _baseSet.AddAsync(entity, cancellationToken);
+    public string GetTopicName() => _baseSet.GetTopicName();
+    public EntityModel GetEntityModel() => _baseSet.GetEntityModel();
+    public IKsqlContext GetContext() => _baseSet.GetContext();
+}

--- a/tests/Extensions/WindowFilterExtensionsTests.cs
+++ b/tests/Extensions/WindowFilterExtensionsTests.cs
@@ -1,0 +1,72 @@
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Extensions;
+using Kafka.Ksql.Linq.Core.Modeling;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Extensions;
+
+public class WindowFilterExtensionsTests
+{
+    private class DummySet<T> : IEntitySet<T>
+        where T : class
+    {
+        private readonly List<T> _items = new();
+        private readonly EntityModel _model;
+        public DummySet(EntityModel model)
+        {
+            _model = model;
+        }
+        public void AddItem(T item) => _items.Add(item);
+        public Task AddAsync(T entity, CancellationToken cancellationToken = default) { _items.Add(entity); return Task.CompletedTask; }
+        public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<T>(_items));
+        public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.WhenAll(_items.Select(action));
+        public string GetTopicName() => _model.TopicName ?? typeof(T).Name.ToLowerInvariant();
+        public EntityModel GetEntityModel() => _model;
+        public IKsqlContext GetContext() => throw new NotImplementedException();
+        public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            foreach (var i in _items)
+            {
+                yield return i;
+                await Task.Yield();
+            }
+        }
+    }
+
+    private class Sample
+    {
+        public int Id { get; set; }
+        public int WindowMinutes { get; set; }
+    }
+
+    private static DummySet<Sample> CreateSet()
+    {
+        var model = new EntityModel
+        {
+            EntityType = typeof(Sample),
+            TopicName = "sample",
+            AllProperties = typeof(Sample).GetProperties(),
+            KeyProperties = new[] { typeof(Sample).GetProperty(nameof(Sample.Id))! },
+            ValidationResult = new ValidationResult { IsValid = true }
+        };
+        return new DummySet<Sample>(model);
+    }
+
+    [Fact]
+    public async Task Window_FiltersByWindowMinutes()
+    {
+        var set = CreateSet();
+        set.AddItem(new Sample { Id = 1, WindowMinutes = 5 });
+        set.AddItem(new Sample { Id = 2, WindowMinutes = 1 });
+
+        var filtered = set.Window(5);
+        var list = await filtered.ToListAsync();
+        Assert.Single(list);
+        Assert.Equal(1, list[0].Id);
+    }
+}


### PR DESCRIPTION
## Summary
- add `WindowFilteredEntitySet` wrapper for filtering by `WindowMinutes`
- add `Window` extension returning filtered set
- test filtering logic
- log progress and diff

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_687b3160849c8327a9b97a0f6fe82ec9