### PR TITLE
Update daily comparison viewer with Window filter

### DIFF
--- a/docs/changes/20250719_progress.md
+++ b/docs/changes/20250719_progress.md
@@ -55,3 +55,5 @@
 
 ## 2025-07-19 15:18 JST [assistant]
 - Documented Window filter usage across README and docs
+## 2025-07-19 15:31 JST [assistant]
+- Updated aggregator and viewer to use Window(x) filter for 1, 5, and 1440 minute bars

--- a/examples/daily-comparison/ComparisonViewer/Program.cs
+++ b/examples/daily-comparison/ComparisonViewer/Program.cs
@@ -1,10 +1,33 @@
 using DailyComparisonLib;
 using DailyComparisonLib.Models;
+using Kafka.Ksql.Linq.Core.Extensions;
 
 await using var context = MyKsqlContext.FromAppSettings("appsettings.json");
 
+var oneMinBars = await context.Set<RateCandle>().Window(1).ToListAsync();
+var fiveMinBars = await context.Set<RateCandle>().Window(5).ToListAsync();
+var dailyBars = await context.Set<RateCandle>().Window(1440).ToListAsync();
 var comparisons = await context.Set<DailyComparison>().ToListAsync();
 
+Console.WriteLine("--- 1 minute bars ---");
+foreach (var c in oneMinBars)
+{
+    Console.WriteLine($"1m {c.WindowStart:t} {c.Symbol} O:{c.Open} H:{c.High} L:{c.Low} C:{c.Close}");
+}
+
+Console.WriteLine("--- 5 minute bars ---");
+foreach (var c in fiveMinBars)
+{
+    Console.WriteLine($"5m {c.WindowStart:t} {c.Symbol} O:{c.Open} H:{c.High} L:{c.Low} C:{c.Close}");
+}
+
+Console.WriteLine("--- Daily bars ---");
+foreach (var c in dailyBars)
+{
+    Console.WriteLine($"day {c.WindowStart:d} {c.Symbol} O:{c.Open} H:{c.High} L:{c.Low} C:{c.Close}");
+}
+
+Console.WriteLine("--- Daily comparison ---");
 foreach (var c in comparisons)
 {
     Console.WriteLine($"{c.Date:d} {c.Broker} {c.Symbol} High:{c.High} Low:{c.Low} Close:{c.Close} Diff:{c.Diff}");

--- a/examples/daily-comparison/DailyComparisonLib/Aggregator.cs
+++ b/examples/daily-comparison/DailyComparisonLib/Aggregator.cs
@@ -1,5 +1,6 @@
 using DailyComparisonLib.Models;
 using Kafka.Ksql.Linq;
+using Kafka.Ksql.Linq.Core.Extensions;
 using System.Linq;
 
 namespace DailyComparisonLib;
@@ -18,7 +19,9 @@ public class Aggregator
             .Where(d => d.Date == date.Date)
             .ToList();
 
-        var minuteBars = (await _context.Set<RateCandle>().ToListAsync(ct))
+        var minuteBars = (await _context.Set<RateCandle>()
+            .Window(1)
+            .ToListAsync(ct))
             .Where(c => c.WindowStart.Date == date.Date)
             .ToList();
 


### PR DESCRIPTION
## Summary
- filter minute bars in aggregator using `Window(1)`
- show how to fetch each windowed bar set in the comparison viewer
- log progress update

## Testing
- `dotnet test examples/daily-comparison/tests/DailyComparisonLib.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_687b3a27eccc832795eaba42ef1db1e3