### PR TITLE
Update RateCandle to use BarTime

### DIFF
--- a/docs/changes/20250731_progress.md
+++ b/docs/changes/20250731_progress.md
@@ -64,3 +64,5 @@
 ## 2025-07-19 13:55 JST [assistant]
 - moved WindowDslExtensions into src/Core/Modeling folder as part of library core
 - verified build and tests
+## 2025-07-19 15:44 JST [assistant]
+- removed WindowStart/WindowEnd/WindowMinutes from RateCandle and added BarTime property. Updated sample code, tests, and docs.

--- a/examples/daily-comparison/ComparisonViewer/Program.cs
+++ b/examples/daily-comparison/ComparisonViewer/Program.cs
@@ -12,19 +12,19 @@ var comparisons = await context.Set<DailyComparison>().ToListAsync();
 Console.WriteLine("--- 1 minute bars ---");
 foreach (var c in oneMinBars)
 {
-    Console.WriteLine($"1m {c.WindowStart:t} {c.Symbol} O:{c.Open} H:{c.High} L:{c.Low} C:{c.Close}");
+    Console.WriteLine($"1m {c.BarTime:t} {c.Symbol} O:{c.Open} H:{c.High} L:{c.Low} C:{c.Close}");
 }
 
 Console.WriteLine("--- 5 minute bars ---");
 foreach (var c in fiveMinBars)
 {
-    Console.WriteLine($"5m {c.WindowStart:t} {c.Symbol} O:{c.Open} H:{c.High} L:{c.Low} C:{c.Close}");
+    Console.WriteLine($"5m {c.BarTime:t} {c.Symbol} O:{c.Open} H:{c.High} L:{c.Low} C:{c.Close}");
 }
 
 Console.WriteLine("--- Daily bars ---");
 foreach (var c in dailyBars)
 {
-    Console.WriteLine($"day {c.WindowStart:d} {c.Symbol} O:{c.Open} H:{c.High} L:{c.Low} C:{c.Close}");
+    Console.WriteLine($"day {c.BarTime:d} {c.Symbol} O:{c.Open} H:{c.High} L:{c.Low} C:{c.Close}");
 }
 
 Console.WriteLine("--- Daily comparison ---");

--- a/examples/daily-comparison/DailyComparisonLib/Aggregator.cs
+++ b/examples/daily-comparison/DailyComparisonLib/Aggregator.cs
@@ -22,7 +22,7 @@ public class Aggregator
         var minuteBars = (await _context.Set<RateCandle>()
             .Window(1)
             .ToListAsync(ct))
-            .Where(c => c.WindowStart.Date == date.Date)
+            .Where(c => c.BarTime.Date == date.Date)
             .ToList();
 
         return (dailyBars, minuteBars);

--- a/examples/daily-comparison/DailyComparisonLib/KafkaKsqlContext.cs
+++ b/examples/daily-comparison/DailyComparisonLib/KafkaKsqlContext.cs
@@ -27,9 +27,7 @@ public class KafkaKsqlContext : KafkaContext
             {
                 Broker = key.Broker,
                 Symbol = key.Symbol,
-                WindowMinutes = w.BarWidth,
-                WindowStart = w.BarStart,
-                WindowEnd = w.BarStart.AddMinutes(w.BarWidth),
+                BarTime = w.BarStart,
                 High = w.Source.Max(x => x.Bid),
                 Low = w.Source.Min(x => x.Bid),
                 Close = w.Source.OrderByDescending(x => x.RateTimestamp).First().Bid,

--- a/examples/daily-comparison/DailyComparisonLib/RateCandle.cs
+++ b/examples/daily-comparison/DailyComparisonLib/RateCandle.cs
@@ -5,9 +5,7 @@ public class RateCandle
     // Broker and Symbol form the composite primary key so they must not be null.
     public string Broker { get; set; } = null!;
     public string Symbol { get; set; } = null!;
-    public DateTime WindowStart { get; set; }
-    public DateTime WindowEnd { get; set; }
-    public int WindowMinutes { get; set; }
+    public DateTime BarTime { get; set; }
     public decimal Open { get; set; }
     public decimal High { get; set; }
     public decimal Low { get; set; }

--- a/examples/daily-comparison/README.md
+++ b/examples/daily-comparison/README.md
@@ -22,9 +22,7 @@ protected override void OnModelCreating(IModelBuilder modelBuilder)
         {
             Broker = key.Broker,
             Symbol = key.Symbol,
-            WindowMinutes = w.BarWidth,
-            WindowStart = w.BarStart,
-            WindowEnd = w.BarStart.AddMinutes(w.BarWidth),
+            BarTime = w.BarStart,
             Open = w.Source.OrderBy(x => x.RateTimestamp).First().Bid,
             High = w.Source.Max(x => x.Bid),
             Low = w.Source.Min(x => x.Bid),

--- a/examples/daily-comparison/tests/AggregatorTests.cs
+++ b/examples/daily-comparison/tests/AggregatorTests.cs
@@ -75,8 +75,8 @@ public class AggregatorTests
         var daily = new DailyComparison { Broker = "b", Symbol = "s", Date = new DateTime(2024,1,1), High = 2.1m, Low = 1m, Close = 2.1m, PrevClose = 2m, Diff = 0.1m };
         dailySet.AddItem(daily);
 
-        candleSet.AddItem(new RateCandle { Broker = "b", Symbol = "s", WindowStart = new DateTime(2024,1,1,1,0,0), WindowEnd = new DateTime(2024,1,1,1,1,0), WindowMinutes = 1, Open = 1.1m, High = 1.1m, Low = 1m, Close = 1.1m });
-        candleSet.AddItem(new RateCandle { Broker = "b", Symbol = "s", WindowStart = new DateTime(2024,1,1,2,0,0), WindowEnd = new DateTime(2024,1,1,2,1,0), WindowMinutes = 1, Open = 2.1m, High = 2.1m, Low = 2m, Close = 2.1m });
+        candleSet.AddItem(new RateCandle { Broker = "b", Symbol = "s", BarTime = new DateTime(2024,1,1,1,0,0), Open = 1.1m, High = 1.1m, Low = 1m, Close = 1.1m });
+        candleSet.AddItem(new RateCandle { Broker = "b", Symbol = "s", BarTime = new DateTime(2024,1,1,2,0,0), Open = 2.1m, High = 2.1m, Low = 2m, Close = 2.1m });
 
         var aggregator = new Aggregator(new KafkaKsqlContextStub(context));
         var (dailyBars, minuteBars) = await aggregator.AggregateAsync(new DateTime(2024,1,1));


### PR DESCRIPTION
## Summary
- update `RateCandle` class to use `BarTime` instead of window properties
- adjust KafkaKsqlContext mapping
- update aggregator, viewer, tests and README
- log the change

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687b3dc0a448832788cec8af79b8c75e