### PR TITLE
Document Limit and RemoveAsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,26 @@ await context.Set<OrderCandle>()
     .ForEachAsync(...);
 ```
 
+### Set<T>().Limit(N)
+`Limit` を指定すると、Pull Query として N 件だけ取得した時点で処理が終了します。余分
+なレコードは内部で破棄されるため、`ForEachAsync` や `ToListAsync` でも N 件で完了しま
+す。
+
+```csharp
+var recent = await context.Set<Order>()
+    .Limit(100)
+    .ToListAsync();
+```
+
+### RemoveAsync とトムストーン
+`RemoveAsync` を呼び出すと、指定キーに対する値 `null` のメッセージ（トムストーン）がト
+ピックに送信されます。トムストーンは KTable やキャッシュに保存された既存レコードを削
+除するために用いられます。
+
+```csharp
+await context.Orders.RemoveAsync(orderId);
+```
+
 
 ## Quick Start
 1. .NET 6 SDKインストール（dotnet --versionで確認）

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -31,11 +31,14 @@
 | `.WithRetry(int)`              | リトライ設定                  | `EventSet<T>`                     | Stream        | ✅      |
 | `.StartErrorHandling()`        | エラーチェーン開始            | `IErrorHandlingChain<T>`          | Stream        | ✅      |
 | `.WithManualCommit()`          | 手動コミットモード切替        | `IEntityBuilder<T>`               | Subscription  | ✅      |
+| `.Limit(int)`                  | 取得件数を制限する Pull Query | `IEntitySet<T>`                  | Stream/Table  | ✅      |
 
 - `ToList`/`ToListAsync` は Pull Query として実行されます【F:src/Query/Pipeline/DMLQueryGenerator.cs†L27-L34】。
 - `WithManualCommit()` を指定しない `ForEachAsync()` は自動コミット動作となります【F:docs/old/manual_commit.md†L1-L23】。
 - `OnError(ErrorAction.DLQ)` を指定すると DLQ トピックへ送信されます【F:docs/old/defaults.md†L52-L52】。
 - Messaging クラス自体は DLQ 送信処理を持たず、`ErrorOccurred`/`DeserializationError`/`ProduceError` などのイベントを通じて外部で DLQ 送信を行います。
+- `Set<T>().Limit(n)` を指定すると n 件取得後にストリームが終了します。残りのレコードは破棄されます。
+- `RemoveAsync(key)` は値 `null` のトムストーンを送り、KTable やキャッシュから該当キーのデータを削除します。
 - `.Window().BaseOn<TSchedule>` を用いる場合、バーは `[ScheduleRange]` 属性、または `openProp`/`closeProp` パラメータで示された `Open` ～ `Close` の範囲に含まれるデータのみで構成されます。日足生成で `Close` が 6:30 のときは、6:30 未満のデータが当日の終値として扱われます。
 - バーやウィンドウ定義は必ず `KafkaKsqlContext.OnModelCreating` 内で宣言してください。アプリケーション側では定義済みの `Set<T>` を参照するだけです。
 - `WithWindow<Rate, MarketSchedule>()` に続けて `.Select<RateCandle>()` を呼び出すことで、レートからバーエンティティを構成できます。

--- a/docs/changes/20250719_progress.md
+++ b/docs/changes/20250719_progress.md
@@ -60,3 +60,5 @@
 ## 2025-07-19 16:43 JST [assistant]
 - Revised previous-day lookup to use last available bar instead of AddDays(-1)
 - Added helper BuildPrevCloseLookup and updated tests
+## 2025-07-19 09:02 JST [assistant]
+- Documented Set<T>().Limit(N) usage and RemoveAsync tombstone behavior across README and docs

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -516,4 +516,24 @@ public class WindowedOrderSummary
 ```
 これにより、KSQLの変換処理ログを確認することが可能です。
 
+## 9. 削除と件数制限の操作
+
+### Set<T>().Limit(N)
+`Limit` を付与すると、KSQL の `LIMIT` 句を伴う Pull Query が生成されます。取得数が N
+ 件に達した時点で処理が完了し、それ以降のレコードは自動的に破棄されます。
+
+```csharp
+var latest = await context.Set<Trade>()
+    .Limit(50)
+    .ToListAsync();
+```
+
+### RemoveAsync でトムストーン送信
+`RemoveAsync` はキーを指定して値 `null` のメッセージ（トムストーン）をトピックへ送信し
+ます。これにより KTable やキャッシュに保持された同一キーのデータが削除されます。
+
+```csharp
+await context.Trades.RemoveAsync(tradeId);
+```
+
 ## 10. 代表的な利用パターン


### PR DESCRIPTION
## Summary
- document `Set<T>().Limit(N)` usage and pruning
- note that `RemoveAsync` sends tombstone records
- summarize docs changes in progress log

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687b5d1b2ce483278ce5d41ca48ceedc