### PR TITLE
Add Limit extension test

### DIFF
--- a/src/Core/Abstractions/IRemovableEntitySet.cs
+++ b/src/Core/Abstractions/IRemovableEntitySet.cs
@@ -1,0 +1,11 @@
+using System.Threading;
+using System.Threading.Tasks;
+namespace Kafka.Ksql.Linq.Core.Abstractions;
+
+/// <summary>
+/// Optional interface for entity sets supporting removal of items.
+/// </summary>
+public interface IRemovableEntitySet<T> : IEntitySet<T> where T : class
+{
+    Task RemoveAsync(T entity, CancellationToken cancellationToken = default);
+}

--- a/src/EventSetLimitExtensions.cs
+++ b/src/EventSetLimitExtensions.cs
@@ -1,0 +1,43 @@
+using Kafka.Ksql.Linq.Core.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kafka.Ksql.Linq;
+
+/// <summary>
+/// Extensions for limiting the number of items in an entity set.
+/// </summary>
+public static class EventSetLimitExtensions
+{
+    /// <summary>
+    /// Returns the newest <paramref name="count"/> items ordered by BarTime and removes older items when supported.
+    /// </summary>
+    public static async Task<List<T>> Limit<T>(this IEntitySet<T> entitySet, int count, CancellationToken cancellationToken = default) where T : class
+    {
+        if (entitySet == null) throw new ArgumentNullException(nameof(entitySet));
+        if (count < 0) throw new ArgumentOutOfRangeException(nameof(count));
+
+        var items = await entitySet.ToListAsync(cancellationToken);
+        var barTimeProp = typeof(T).GetProperty("BarTime", BindingFlags.Public | BindingFlags.Instance);
+        if (barTimeProp == null)
+            throw new InvalidOperationException($"Type {typeof(T).Name} must have BarTime property.");
+
+        var ordered = items.OrderByDescending(i => (DateTime)barTimeProp.GetValue(i)!).ToList();
+        var toKeep = ordered.Take(count).ToList();
+        var toRemove = ordered.Skip(count).ToList();
+
+        if (entitySet is IRemovableEntitySet<T> removable)
+        {
+            foreach (var item in toRemove)
+            {
+                await removable.RemoveAsync(item, cancellationToken);
+            }
+        }
+
+        return toKeep;
+    }
+}

--- a/tests/EventSetLimitExtensionsTests.cs
+++ b/tests/EventSetLimitExtensionsTests.cs
@@ -1,0 +1,85 @@
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Modeling;
+using Kafka.Ksql.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests;
+
+public class EventSetLimitExtensionsTests
+{
+    private class RateCandle
+    {
+        public DateTime BarTime { get; set; }
+    }
+
+    private class DummyContext : IKsqlContext
+    {
+        public IEntitySet<T> Set<T>() where T : class => throw new NotImplementedException();
+        public object GetEventSet(Type entityType) => throw new NotImplementedException();
+        public Dictionary<Type, EntityModel> GetEntityModels() => new();
+        public void Dispose() { }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private class DummySet : IRemovableEntitySet<RateCandle>
+    {
+        private readonly List<RateCandle> _items;
+        public List<RateCandle> Removed { get; } = new();
+        private readonly EntityModel _model = new()
+        {
+            EntityType = typeof(RateCandle),
+            TopicName = "ratecandle",
+            AllProperties = typeof(RateCandle).GetProperties(),
+            KeyProperties = Array.Empty<System.Reflection.PropertyInfo>()
+        };
+        public DummySet(IEnumerable<RateCandle> items)
+        {
+            _items = items.ToList();
+        }
+        public Task AddAsync(RateCandle entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<List<RateCandle>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(_items.ToList());
+        public Task ForEachAsync(Func<RateCandle, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.WhenAll(_items.Select(action));
+        public string GetTopicName() => _model.TopicName!;
+        public EntityModel GetEntityModel() => _model;
+        public IKsqlContext GetContext() => new DummyContext();
+        public async IAsyncEnumerator<RateCandle> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            foreach (var item in _items)
+            {
+                yield return item;
+                await Task.Yield();
+            }
+        }
+        public Task RemoveAsync(RateCandle entity, CancellationToken cancellationToken = default)
+        {
+            Removed.Add(entity);
+            _items.Remove(entity);
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task Limit_RemovesOldItemsAndReturnsNewest()
+    {
+        var items = new List<RateCandle>
+        {
+            new RateCandle { BarTime = new DateTime(2024,1,1,1,0,0) },
+            new RateCandle { BarTime = new DateTime(2024,1,1,2,0,0) },
+            new RateCandle { BarTime = new DateTime(2024,1,1,3,0,0) }
+        };
+        var set = new DummySet(items);
+
+        var result = await set.Limit(2);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(new DateTime(2024,1,1,3,0,0), result[0].BarTime);
+        Assert.Equal(new DateTime(2024,1,1,2,0,0), result[1].BarTime);
+        Assert.Single(set.Removed);
+        Assert.Equal(new DateTime(2024,1,1,1,0,0), set.Removed[0].BarTime);
+    }
+}


### PR DESCRIPTION
## Summary
- add `IRemovableEntitySet` interface
- implement `EventSetLimitExtensions` with a `Limit` helper
- add `EventSetLimitExtensionsTests` verifying removal and ordering

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --logger "console;verbosity=normal"`

------
https://chatgpt.com/codex/tasks/task_e_687b5d9a401c8327931943a0f05e3714