### PR TITLE
Implement configurable bar limits

### DIFF
--- a/examples/daily-comparison/DailyComparisonLib/Aggregator.cs
+++ b/examples/daily-comparison/DailyComparisonLib/Aggregator.cs
@@ -1,6 +1,7 @@
 using DailyComparisonLib.Models;
 using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Core.Extensions;
+using Kafka.Ksql.Linq.Configuration;
 using System.Linq;
 
 namespace DailyComparisonLib;
@@ -8,9 +9,12 @@ namespace DailyComparisonLib;
 public class Aggregator
 {
     private readonly KafkaKsqlContext _context;
-    public Aggregator(KafkaKsqlContext context)
+    private readonly BarLimitOptions _limitOptions;
+
+    public Aggregator(KafkaKsqlContext context, BarLimitOptions? limitOptions = null)
     {
         _context = context;
+        _limitOptions = limitOptions ?? new BarLimitOptions();
     }
 
     public async Task<(List<DailyComparison> DailyBars, List<RateCandle> MinuteBars)> AggregateAsync(DateTime date, CancellationToken ct = default)
@@ -21,6 +25,12 @@ public class Aggregator
 
         var minuteBars = (await _context.Set<RateCandle>().ToListAsync(ct))
             .Where(c => c.BarTime.Date == date.Date)
+            .GroupBy(c => c.Symbol)
+            .SelectMany(g =>
+            {
+                var limit = _limitOptions.GetLimit(g.Key, nameof(RateCandle));
+                return g.OrderByDescending(b => b.BarTime).Take(limit);
+            })
             .ToList();
 
         return (dailyBars, minuteBars);

--- a/examples/daily-comparison/RateSender/Program.cs
+++ b/examples/daily-comparison/RateSender/Program.cs
@@ -25,5 +25,5 @@ for (int i = 0; i < 100; i++)
     await Task.Delay(1000);
 }
 
-var aggregator = new Aggregator(context);
+var aggregator = new Aggregator(context, null);
 await aggregator.AggregateAsync(DateTime.UtcNow.Date);

--- a/examples/daily-comparison/tests/AggregatorTests.cs
+++ b/examples/daily-comparison/tests/AggregatorTests.cs
@@ -78,7 +78,7 @@ public class AggregatorTests
         candleSet.AddItem(new RateCandle { Broker = "b", Symbol = "s", BarTime = new DateTime(2024,1,1,1,0,0), Open = 1.1m, High = 1.1m, Low = 1m, Close = 1.1m });
         candleSet.AddItem(new RateCandle { Broker = "b", Symbol = "s", BarTime = new DateTime(2024,1,1,2,0,0), Open = 2.1m, High = 2.1m, Low = 2m, Close = 2.1m });
 
-        var aggregator = new Aggregator(new KafkaKsqlContextStub(context));
+        var aggregator = new Aggregator(new KafkaKsqlContextStub(context), null);
         var (dailyBars, minuteBars) = await aggregator.AggregateAsync(new DateTime(2024,1,1));
 
         var result = Assert.Single(dailyBars);

--- a/src/Configuration/BarLimitOptions.cs
+++ b/src/Configuration/BarLimitOptions.cs
@@ -1,0 +1,22 @@
+namespace Kafka.Ksql.Linq.Configuration;
+
+using System.Collections.Generic;
+using System.Linq;
+
+public class BarLimitOptions
+{
+    public List<BarLimitEntry> Limits { get; set; } = new();
+
+    public int GetLimit(string symbol, string barType)
+    {
+        var entry = Limits.FirstOrDefault(e => e.Symbol == symbol && e.BarType == barType);
+        return entry?.Limit ?? int.MaxValue;
+    }
+}
+
+public class BarLimitEntry
+{
+    public string Symbol { get; set; } = string.Empty;
+    public string BarType { get; set; } = string.Empty;
+    public int Limit { get; set; }
+}

--- a/src/Configuration/KsqlDslOptions.cs
+++ b/src/Configuration/KsqlDslOptions.cs
@@ -42,4 +42,9 @@ public class KsqlDslOptions
     /// Whether reading from the Final topic is enabled by default
     /// </summary>
     public bool ReadFromFinalTopicByDefault { get; set; } = false;
+
+    /// <summary>
+    /// Optional bar limits per symbol and bar type
+    /// </summary>
+    public BarLimitOptions BarLimits { get; init; } = new();
 }


### PR DESCRIPTION
## Summary
- add `BarLimitOptions` and wire into `KsqlDslOptions`
- allow `Aggregator` to prune bars per symbol using configured limits

## Testing
- `dotnet build Kafka.Ksql.Linq.sln -c Release`
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj -v minimal`
- `dotnet test examples/daily-comparison/tests/DailyComparisonLib.Tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_687b5dae188c8327ad1abc134acfa887