### PR TITLE
Add Limit API with tombstone deletion

### DIFF
--- a/docs/changes/20250719_progress.md
+++ b/docs/changes/20250719_progress.md
@@ -60,3 +60,7 @@
 ## 2025-07-19 16:43 JST [assistant]
 - Revised previous-day lookup to use last available bar instead of AddDays(-1)
 - Added helper BuildPrevCloseLookup and updated tests
+## 2025-07-19 17:39 JST [assistant]
+- updated DeleteAsync logic to build Avro key from entity
+- fixed test stubs to implement new methods
+

--- a/src/Cache/Core/ReadCachedEntitySet.cs
+++ b/src/Cache/Core/ReadCachedEntitySet.cs
@@ -48,6 +48,11 @@ internal class ReadCachedEntitySet<T> : IEntitySet<T> where T : class
         return _baseSet.AddAsync(entity, cancellationToken);
     }
 
+    public Task RemoveAsync(T entity, CancellationToken cancellationToken = default)
+    {
+        return _baseSet.RemoveAsync(entity, cancellationToken);
+    }
+
     public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default)
     {
         return _baseSet.ForEachAsync(action, timeout, cancellationToken);

--- a/src/Core/Abstractions/IEntitySet.cs
+++ b/src/Core/Abstractions/IEntitySet.cs
@@ -13,6 +13,7 @@ public interface IEntitySet<T> : IAsyncEnumerable<T> where T : class
 {
     // Producer operations
     Task AddAsync(T entity, CancellationToken cancellationToken = default);
+    Task RemoveAsync(T entity, CancellationToken cancellationToken = default);
 
     // Consumer operations
     Task<List<T>> ToListAsync(CancellationToken cancellationToken = default);

--- a/src/Core/Window/WindowAggregatedEntitySet.cs
+++ b/src/Core/Window/WindowAggregatedEntitySet.cs
@@ -67,6 +67,11 @@ internal class WindowAggregatedEntitySet<TSource, TKey, TResult> : IEntitySet<TR
         throw new NotSupportedException("Cannot add entities to a window aggregated result set");
     }
 
+    public Task RemoveAsync(TResult entity, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException("Cannot remove entities from a window aggregated result set");
+    }
+
     public async Task<List<TResult>> ToListAsync(CancellationToken cancellationToken = default)
     {
         try

--- a/src/Core/Window/WindowFilteredEntitySet.cs
+++ b/src/Core/Window/WindowFilteredEntitySet.cs
@@ -59,6 +59,7 @@ internal class WindowFilteredEntitySet<T> : IEntitySet<T> where T : class
     }
 
     public Task AddAsync(T entity, CancellationToken cancellationToken = default) => _baseSet.AddAsync(entity, cancellationToken);
+    public Task RemoveAsync(T entity, CancellationToken cancellationToken = default) => _baseSet.RemoveAsync(entity, cancellationToken);
     public string GetTopicName() => _baseSet.GetTopicName();
     public EntityModel GetEntityModel() => _baseSet.GetEntityModel();
     public IKsqlContext GetContext() => _baseSet.GetContext();

--- a/src/Core/Window/WindowedEntitySet.cs
+++ b/src/Core/Window/WindowedEntitySet.cs
@@ -108,6 +108,11 @@ internal class WindowedEntitySet<T> : IWindowedEntitySet<T> where T : class
         await _baseEntitySet.AddAsync(entity, cancellationToken);
     }
 
+    public Task RemoveAsync(T entity, CancellationToken cancellationToken = default)
+    {
+        return _baseEntitySet.RemoveAsync(entity, cancellationToken);
+    }
+
     public async Task<List<T>> ToListAsync(CancellationToken cancellationToken = default)
     {
         // ウィンドウクエリは集約前の生データは通常取得しない

--- a/src/EventSet.cs
+++ b/src/EventSet.cs
@@ -118,6 +118,11 @@ public abstract class EventSet<T> : IEntitySet<T> where T : class
 
         await SendEntityAsync(entity, cancellationToken);
     }
+
+    public virtual Task RemoveAsync(T entity, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException($"RemoveAsync is not supported for {GetType().Name}.");
+    }
     /// <summary>
     /// REDESIGNED: ForEachAsync supporting continuous Kafka consumption
     /// Design change: ToListAsync() is disallowed; now based on GetAsyncEnumerator
@@ -498,6 +503,11 @@ internal class MappedEventSet<T> : EventSet<T> where T : class
         throw new NotSupportedException(
             $"MappedEventSet<{typeof(T).Name}> does not support AddAsync operations. " +
             "Mapped data is read-only and derived from transformation operations.");
+    }
+
+    public override Task RemoveAsync(T entity, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException($"MappedEventSet<{typeof(T).Name}> does not support RemoveAsync operations.");
     }
 
     /// <summary>

--- a/src/EventSetLimitExtensions.cs
+++ b/src/EventSetLimitExtensions.cs
@@ -1,0 +1,33 @@
+using Kafka.Ksql.Linq.Core.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kafka.Ksql.Linq;
+
+public static class EventSetLimitExtensions
+{
+    public static async Task<List<T>> Limit<T>(this IEntitySet<T> set, int count, CancellationToken cancellationToken = default) where T : class
+    {
+        if (set == null) throw new ArgumentNullException(nameof(set));
+        if (count <= 0) throw new ArgumentOutOfRangeException(nameof(count));
+
+        var list = await set.ToListAsync(cancellationToken);
+        var barTimeProp = typeof(T).GetProperty("BarTime", BindingFlags.Public | BindingFlags.Instance);
+        if (barTimeProp != null)
+        {
+            list = list.OrderByDescending(x => (DateTime)barTimeProp.GetValue(x)!).ToList();
+        }
+        var limited = list.Take(count).ToList();
+
+        foreach (var extra in list.Skip(count))
+        {
+            await set.RemoveAsync(extra, cancellationToken);
+        }
+
+        return limited;
+    }
+}

--- a/src/KsqlContext.cs
+++ b/src/KsqlContext.cs
@@ -8,6 +8,7 @@ using Kafka.Ksql.Linq.Core.Dlq;
 using Kafka.Ksql.Linq.Query.Abstractions;
 using Kafka.Ksql.Linq.Cache.Extensions;
 using Kafka.Ksql.Linq.Cache.Core;
+using Kafka.Ksql.Linq.Core.Models;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
@@ -342,6 +343,22 @@ internal class EventSetWithServices<T> : IEntitySet<T> where T : class
         catch (Exception ex)
         {
             throw new InvalidOperationException($"Failed to send entity {typeof(T).Name} to Kafka", ex);
+        }
+    }
+
+    public async Task RemoveAsync(T entity, CancellationToken cancellationToken = default)
+    {
+        if (entity == null)
+            throw new ArgumentNullException(nameof(entity));
+
+        try
+        {
+            var producerManager = _ksqlContext.GetProducerManager();
+            await producerManager.DeleteAsync(entity, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Failed to delete entity {typeof(T).Name} from Kafka", ex);
         }
     }
 

--- a/src/Messaging/Abstractions/IKafkaProducer.cs
+++ b/src/Messaging/Abstractions/IKafkaProducer.cs
@@ -29,6 +29,11 @@ public interface IKafkaProducer<T> : IDisposable where T : class
     Task FlushAsync(TimeSpan timeout);
 
     /// <summary>
+    /// Tombstone を送信してメッセージを削除します
+    /// </summary>
+    Task<KafkaDeliveryResult> DeleteAsync(object key, KafkaMessageContext? context = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// トピック名取得
     /// </summary>
     string TopicName { get; }

--- a/src/Query/Linq/JoinableEntitySet.cs
+++ b/src/Query/Linq/JoinableEntitySet.cs
@@ -27,6 +27,11 @@ public class JoinableEntitySet<T> : IEntitySet<T>, IJoinableEntitySet<T> where T
         await _baseEntitySet.AddAsync(entity, cancellationToken);
     }
 
+    public async Task RemoveAsync(T entity, CancellationToken cancellationToken = default)
+    {
+        await _baseEntitySet.RemoveAsync(entity, cancellationToken);
+    }
+
     public async Task<List<T>> ToListAsync(CancellationToken cancellationToken = default)
     {
         return await _baseEntitySet.ToListAsync(cancellationToken);

--- a/src/Query/Linq/TypedJoinResultEntitySet.cs
+++ b/src/Query/Linq/TypedJoinResultEntitySet.cs
@@ -50,6 +50,11 @@ internal class TypedJoinResultEntitySet<TOuter, TInner, TResult> : IEntitySet<TR
         throw new NotSupportedException("Cannot add entities to a join result set");
     }
 
+    public Task RemoveAsync(TResult entity, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException("Cannot remove entities from a join result set");
+    }
+
     public Task ForEachAsync(Func<TResult, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default)
     {
         throw new NotSupportedException("ForEachAsync not supported on join result sets");

--- a/src/Query/Linq/TypedThreeWayJoinResultEntitySet.cs
+++ b/src/Query/Linq/TypedThreeWayJoinResultEntitySet.cs
@@ -60,6 +60,11 @@ internal class TypedThreeWayJoinResultEntitySet<TOuter, TInner, TThird, TResult>
         throw new NotSupportedException("Cannot add entities to a three-way join result set");
     }
 
+    public Task RemoveAsync(TResult entity, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException("Cannot remove entities from a three-way join result set");
+    }
+
     public Task ForEachAsync(Func<TResult, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default)
     {
         throw new NotSupportedException("ForEachAsync not supported on three-way join result sets");

--- a/tests/Application/EventSetWithServicesSendTests.cs
+++ b/tests/Application/EventSetWithServicesSendTests.cs
@@ -28,6 +28,8 @@ public class EventSetWithServicesSendTests
             Sent = true;
             return Task.FromResult(new KafkaDeliveryResult());
         }
+        public Task<KafkaDeliveryResult> DeleteAsync(object key, KafkaMessageContext? context = null, CancellationToken cancellationToken = default)
+            => Task.FromResult(new KafkaDeliveryResult());
         // Batch sending removed
         public Task FlushAsync(TimeSpan timeout) => Task.CompletedTask;
         public void Dispose() { }

--- a/tests/Application/KsqlContextDlqSendTests.cs
+++ b/tests/Application/KsqlContextDlqSendTests.cs
@@ -29,6 +29,8 @@ public class KsqlContextDlqSendTests
             Sent = true;
             return Task.FromResult(new KafkaDeliveryResult());
         }
+        public Task<KafkaDeliveryResult> DeleteAsync(object key, KafkaMessageContext? context = null, CancellationToken cancellationToken = default)
+            => Task.FromResult(new KafkaDeliveryResult());
         // Batch sending removed
         public Task FlushAsync(TimeSpan timeout) => Task.CompletedTask;
         public void Dispose() { }

--- a/tests/Core/Window/WindowAggregatedEntitySetTests.cs
+++ b/tests/Core/Window/WindowAggregatedEntitySetTests.cs
@@ -31,6 +31,7 @@ public class WindowAggregatedEntitySetTests
             _model = model;
         }
         public Task AddAsync(T entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task RemoveAsync(T entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<T>());
         public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public string GetTopicName() => _model.TopicName ?? typeof(T).Name.ToLowerInvariant();

--- a/tests/Core/Window/WindowCollectionTests.cs
+++ b/tests/Core/Window/WindowCollectionTests.cs
@@ -31,6 +31,7 @@ public class WindowCollectionTests
             _model = model;
         }
         public Task AddAsync(T entity, CancellationToken cancellationToken = default) { Items.Add(entity); return Task.CompletedTask; }
+        public Task RemoveAsync(T entity, CancellationToken cancellationToken = default) { Items.Remove(entity); return Task.CompletedTask; }
         public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<T>(Items));
         public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.WhenAll(Items.Select(action));
         public string GetTopicName() => _model.TopicName ?? typeof(T).Name.ToLowerInvariant();

--- a/tests/Core/Window/WindowedEntitySetTests.cs
+++ b/tests/Core/Window/WindowedEntitySetTests.cs
@@ -31,6 +31,7 @@ public class WindowedEntitySetTests
             _model = model;
         }
         public Task AddAsync(T entity, CancellationToken cancellationToken = default) { Items.Add(entity); return Task.CompletedTask; }
+        public Task RemoveAsync(T entity, CancellationToken cancellationToken = default) { Items.Remove(entity); return Task.CompletedTask; }
         public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<T>(Items));
         public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.WhenAll(Items.Select(action));
         public string GetTopicName() => _model.TopicName ?? typeof(T).Name.ToLowerInvariant();

--- a/tests/Extensions/ScheduleWindowBuilderTests.cs
+++ b/tests/Extensions/ScheduleWindowBuilderTests.cs
@@ -117,6 +117,7 @@ public class ScheduleWindowBuilderTests
         public Expression Expression => _query.Expression;
         public IQueryProvider Provider => _query.Provider;
         public Task AddAsync(T entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task RemoveAsync(T entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(_query.ToList());
         public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.WhenAll(_query.Select(action));
         public string GetTopicName() => _model.TopicName ?? typeof(T).Name.ToLowerInvariant();

--- a/tests/Extensions/WindowFilterExtensionsTests.cs
+++ b/tests/Extensions/WindowFilterExtensionsTests.cs
@@ -23,6 +23,7 @@ public class WindowFilterExtensionsTests
         }
         public void AddItem(T item) => _items.Add(item);
         public Task AddAsync(T entity, CancellationToken cancellationToken = default) { _items.Add(entity); return Task.CompletedTask; }
+        public Task RemoveAsync(T entity, CancellationToken cancellationToken = default) { _items.Remove(entity); return Task.CompletedTask; }
         public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<T>(_items));
         public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.WhenAll(_items.Select(action));
         public string GetTopicName() => _model.TopicName ?? typeof(T).Name.ToLowerInvariant();

--- a/tests/Mapping/AddAsyncSampleFlowTests.cs
+++ b/tests/Mapping/AddAsyncSampleFlowTests.cs
@@ -32,6 +32,8 @@ public class AddAsyncSampleFlowTests
             Sent = true;
             return Task.FromResult(new KafkaDeliveryResult());
         }
+        public Task<KafkaDeliveryResult> DeleteAsync(object key, KafkaMessageContext? context = null, CancellationToken cancellationToken = default)
+            => Task.FromResult(new KafkaDeliveryResult());
         // Batch sending removed
         public Task FlushAsync(System.TimeSpan timeout) => Task.CompletedTask;
         public void Dispose() { }

--- a/tests/Mapping/AutomaticQueryFlowTests.cs
+++ b/tests/Mapping/AutomaticQueryFlowTests.cs
@@ -33,6 +33,8 @@ public class AutomaticQueryFlowTests
             Sent = true;
             return Task.FromResult(new KafkaDeliveryResult());
         }
+        public Task<KafkaDeliveryResult> DeleteAsync(object key, KafkaMessageContext? context = null, CancellationToken cancellationToken = default)
+            => Task.FromResult(new KafkaDeliveryResult());
         // Batch sending removed
         public Task FlushAsync(System.TimeSpan timeout) => Task.CompletedTask;
         public void Dispose() { }

--- a/tests/Mapping/FullAutoQueryFlowTests.cs
+++ b/tests/Mapping/FullAutoQueryFlowTests.cs
@@ -34,6 +34,8 @@ public class FullAutoQueryFlowTests
             Sent = true;
             return Task.FromResult(new KafkaDeliveryResult());
         }
+        public Task<KafkaDeliveryResult> DeleteAsync(object key, KafkaMessageContext? context = null, CancellationToken cancellationToken = default)
+            => Task.FromResult(new KafkaDeliveryResult());
         // Batch sending removed
         public Task FlushAsync(System.TimeSpan timeout) => Task.CompletedTask;
         public void Dispose() { }

--- a/tests/Messaging/KafkaProducerManagerDisposeTests.cs
+++ b/tests/Messaging/KafkaProducerManagerDisposeTests.cs
@@ -32,6 +32,8 @@ public class KafkaProducerManagerDisposeTests
             Sent = true;
             return Task.FromResult(new KafkaDeliveryResult());
         }
+        public Task<KafkaDeliveryResult> DeleteAsync(object key, KafkaMessageContext? context = null, CancellationToken cancellationToken = default)
+            => Task.FromResult(new KafkaDeliveryResult());
         // Batch sending removed
         public Task FlushAsync(TimeSpan timeout) => Task.CompletedTask;
         public void Dispose() { Disposed = true; }

--- a/tests/Query/JoinableEntitySetTests.cs
+++ b/tests/Query/JoinableEntitySetTests.cs
@@ -26,6 +26,7 @@ public class JoinableEntitySetTests
     {
         private readonly IKsqlContext _context = new DummyContext();
         public Task AddAsync(T entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task RemoveAsync(T entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<T>());
         public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public string GetTopicName() => typeof(T).Name;

--- a/tests/Query/TypedJoinResultEntitySetTests.cs
+++ b/tests/Query/TypedJoinResultEntitySetTests.cs
@@ -25,6 +25,7 @@ public class TypedJoinResultEntitySetTests
     {
         private readonly IKsqlContext _context = new DummyContext();
         public Task AddAsync(T entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task RemoveAsync(T entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<T>());
         public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public string GetTopicName() => typeof(T).Name;


### PR DESCRIPTION
## Summary
- add `DeleteAsync` to producer interfaces and implementations
- support removal via `IEntitySet.RemoveAsync`
- hook removal into `KsqlContext` and wrapper sets
- implement `Limit` extension to prune old bars
- refine tombstone deletion to build Avro keys
- update unit test stubs for new methods

## Testing
- `dotnet test Kafka.Ksql.Linq.sln --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_687b52f4d9188327be9367c13e9cea18