### PR TITLE
Refactor aggregator to use bar time selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ var recent = await context.Set<Order>()
     .ToListAsync();
 ```
 
+`Limit` がバーエンティティに適用される場合、`WithWindow().Select<TBar>()`
+で `BarTime` プロパティへ代入した式が自動的に抽出され、並び替えに利用されます。
+追加の設定は不要です。
+
 ### RemoveAsync とトムストーン
 `RemoveAsync` を呼び出すと、指定キーに対する値 `null` のメッセージ（トムストーン）がト
 ピックに送信されます。トムストーンは KTable やキャッシュに保存された既存レコードを削

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -38,6 +38,7 @@
 - `OnError(ErrorAction.DLQ)` を指定すると DLQ トピックへ送信されます【F:docs/old/defaults.md†L52-L52】。
 - Messaging クラス自体は DLQ 送信処理を持たず、`ErrorOccurred`/`DeserializationError`/`ProduceError` などのイベントを通じて外部で DLQ 送信を行います。
 - `Set<T>().Limit(n)` を指定すると n 件取得後にストリームが終了します。残りのレコードは破棄されます。
+- バーエンティティでは `WithWindow().Select<TBar>()` で `BarTime` に代入した式が自動的に記録され、`Limit` の並び替えに使用されます。
 - `RemoveAsync(key)` は値 `null` のトムストーンを送り、KTable やキャッシュから該当キーのデータを削除します。
 - `.Window().BaseOn<TSchedule>` を用いる場合、バーは `[ScheduleRange]` 属性、または `openProp`/`closeProp` パラメータで示された `Open` ～ `Close` の範囲に含まれるデータのみで構成されます。日足生成で `Close` が 6:30 のときは、6:30 未満のデータが当日の終値として扱われます。
 - バーやウィンドウ定義は必ず `KafkaKsqlContext.OnModelCreating` 内で宣言してください。アプリケーション側では定義済みの `Set<T>` を参照するだけです。

--- a/docs/changes/20250731_progress.md
+++ b/docs/changes/20250731_progress.md
@@ -66,3 +66,8 @@
 - verified build and tests
 ## 2025-07-19 15:44 JST [assistant]
 - removed WindowStart/WindowEnd/WindowMinutes from RateCandle and added BarTime property. Updated sample code, tests, and docs.
+## 2025-07-19 18:32 JST [assistant]
+- implemented BarTime selector extraction and updated Limit extension to avoid reflection
+
+## 2025-07-19 18:58 JST [assistant]
+- switched aggregator to use BarTimeSelector and updated docs

--- a/docs/diff_log/diff_bar_time_selector_20250719.md
+++ b/docs/diff_log/diff_bar_time_selector_20250719.md
@@ -1,0 +1,19 @@
+# 差分履歴: bar_time_selector
+
+🗕 2025-07-19 (JST)
+🧐 作業者: assistant
+
+## 差分タイトル
+BarTime セレクター自動抽出と Limit API 更新
+
+## 変更理由
+Bar エンティティの時刻プロパティ名を固定せず、`Select<RateCandle>` で指定した割り当てから自動取得することで拡張性を高めるため。
+
+## 追加・修正内容（反映先: oss_design_combined.md）
+- `EntityModel` に `BarTimeSelector` プロパティを追加
+- `WindowSelectionBuilder.Select` で `BarTime` への代入を解析しセレクターを保存
+- `EventSetLimitExtensions.Limit` で `BarTimeSelector` を使用して並び替え・削除を実行
+- テスト `EventSetLimitExtensionsTests` を更新
+
+## 参考文書
+- `docs/api_reference.md` Window セクション

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -528,6 +528,10 @@ var latest = await context.Set<Trade>()
     .ToListAsync();
 ```
 
+バー生成に `WithWindow().Select<TBar>()` を使用している場合、`BarTime` への
+代入式から自動的にタイムスタンプセレクターが取得され、`Limit` の並び替えに活用
+されます。
+
 ### RemoveAsync でトムストーン送信
 `RemoveAsync` はキーを指定して値 `null` のメッセージ（トムストーン）をトピックへ送信し
 ます。これにより KTable やキャッシュに保持された同一キーのデータが削除されます。

--- a/examples/daily-comparison/tests/AggregatorTests.cs
+++ b/examples/daily-comparison/tests/AggregatorTests.cs
@@ -67,6 +67,7 @@ public class AggregatorTests
         var scheduleSet = new DummySet<MarketSchedule>(context);
         var dailySet = new DummySet<DailyComparison>(context);
         var candleSet = new DummySet<RateCandle>(context);
+        candleSet.GetEntityModel().BarTimeSelector = (Expression<Func<RateCandle, DateTime>>)(x => x.BarTime);
         context.AddSet(rateSet);
         context.AddSet(scheduleSet);
         context.AddSet(dailySet);

--- a/src/Core/Abstractions/EntityModel.cs
+++ b/src/Core/Abstractions/EntityModel.cs
@@ -2,6 +2,7 @@ using Kafka.Ksql.Linq.Query.Abstractions;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Linq.Expressions;
 
 namespace Kafka.Ksql.Linq.Core.Abstractions;
 
@@ -16,6 +17,14 @@ public class EntityModel
     public PropertyInfo[] KeyProperties { get; set; } = Array.Empty<PropertyInfo>();
 
     public PropertyInfo[] AllProperties { get; set; } = Array.Empty<PropertyInfo>();
+
+    /// <summary>
+    /// Optional selector expression identifying the bar timestamp used for
+    /// ordering or limiting operations. This is automatically populated when
+    /// <c>Select&lt;TResult&gt;()</c> is used with Window DSL and a property assignment
+    /// from <c>WindowGrouping.BarStart</c> is detected.
+    /// </summary>
+    public LambdaExpression? BarTimeSelector { get; set; }
 
     /// <summary>
     /// Indicates whether this entity is used for reading, writing, or both.

--- a/src/Core/Abstractions/IRemovableEntitySet.cs
+++ b/src/Core/Abstractions/IRemovableEntitySet.cs
@@ -7,5 +7,5 @@ namespace Kafka.Ksql.Linq.Core.Abstractions;
 /// </summary>
 public interface IRemovableEntitySet<T> : IEntitySet<T> where T : class
 {
-    Task RemoveAsync(T entity, CancellationToken cancellationToken = default);
+    new Task RemoveAsync(T entity, CancellationToken cancellationToken = default);
 }

--- a/tests/EventSetLimitExtensionsTests.cs
+++ b/tests/EventSetLimitExtensionsTests.cs
@@ -4,6 +4,7 @@ using Kafka.Ksql.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -40,6 +41,7 @@ public class EventSetLimitExtensionsTests
         public DummySet(IEnumerable<RateCandle> items)
         {
             _items = items.ToList();
+            _model.BarTimeSelector = (Expression<Func<RateCandle, DateTime>>)(x => x.BarTime);
         }
         public Task AddAsync(RateCandle entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task<List<RateCandle>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(_items.ToList());


### PR DESCRIPTION
## Summary
- use `BarTimeSelector` in `Aggregator` for ordering and limiting
- record bar time selector for tests
- document automatic bar time selection for `Limit`
- update progress log

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687b6519e62c8327995334eb688582a1