### PR TITLE
Fix BuildTypedKey default

### DIFF
--- a/src/Core/Models/KeyExtractor.cs
+++ b/src/Core/Models/KeyExtractor.cs
@@ -91,7 +91,7 @@ internal static class KeyExtractor
     internal static object BuildTypedKey(IList<CompositeKeyPart> parts, ILogger? logger = null)
     {
         if (parts.Count == 0)
-            return Guid.NewGuid();
+            return Guid.NewGuid().ToString();
 
         if (parts.Count == 1)
         {


### PR DESCRIPTION
## Summary
- fix default key type in `BuildTypedKey` to use string

## Testing
- `dotnet test Kafka.Ksql.Linq.sln --no-restore --filter Category!=Integration --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_687c160686c8832795c730ccb500745f