### PR TITLE
Update namespace docs

### DIFF
--- a/docs/namespaces/cache_namespace_doc.md
+++ b/docs/namespaces/cache_namespace_doc.md
@@ -14,7 +14,8 @@ Streamiz.Kafka.Net の `KafkaStream` を利用し、RocksDB ベースの状態�
    - `ToListAsync()` などデータ取得時に `RUNNING` でなければ例外を返す
    - 通常は `IKsqlContext.Set<T>()` から透過的に利用される
 3. **設定連携**
-   - `appsettings.json` の `TableCache` セクションからキャッシュの有効 / 無効、ディレクトリなどを読み込む
+   - `appsettings.json` の `TableCache` セクションからキャッシュ有効フラグ、`BaseDirectory`、`StoreName` などを読み込む
+   - `StoreName` を省略した場合はトピック名に基づく名前を自動生成する
 
 このキャッシュは Table 型の EntitySet でデフォルト有効となり、高速な再読込を実現します。
 

--- a/docs/namespaces/core_namespace_doc.md
+++ b/docs/namespaces/core_namespace_doc.md
@@ -66,8 +66,8 @@ Kafka.Ksql.Linq.Coreは、Apache KafkaとKsqlDBを使ったストリーミング
 - **純粋性重視**: 副作用のない関数型設計を採用
 - **ログフリー**: Infrastructure層でログ処理を実装
 
-### 主要パターン
-- **POCO属性主導**: `[Topic]` 属性によるエンティティ定義（キーはプロパティ定義順から自動生成）
+-### 主要パターン
+- **Fluent API主体**: `EntityModelBuilder<T>` で `HasTopic()` や `HasKey()` を記述
 - **Fluent API**: ModelBuilderによる設定の補完
 - **LINQ互換**: `IAsyncEnumerable<T>`ベースの統一インターフェース
 - **エラーハンドリング**: Skip/Retry/DLQの3段階対応

--- a/docs/namespaces/messaging_namespace_doc.md
+++ b/docs/namespaces/messaging_namespace_doc.md
@@ -40,11 +40,7 @@ Kafka メッセージング機能の型安全な抽象化層を提供する name
 - **`KafkaConsumerManager`**: Consumer の型安全管理
 - **`KafkaBatch<TValue, TKey>`**: バッチ消費結果
 
-#### プール管理（廃止予定）
-- **`PooledConsumer`**: プールされた Consumer（Pool 削除方針）
-- **`ConsumerInstance`**: Consumer インスタンス管理
-
-**設計意図**: Pool 削除によるシンプル化、購読パターンの統一
+プール機構は廃止され、単一インスタンスでの購読管理に統一されている。
 
 ### 5. Contracts - エラーハンドリング契約
 - **`IErrorSink`**: エラーレコード処理インターフェース（DLQ送信等）

--- a/docs/namespaces/window_namespace_doc.md
+++ b/docs/namespaces/window_namespace_doc.md
@@ -126,15 +126,15 @@
 
 ## 外部依存関係
 
-- **IKafkaProducer**: 最終トピックへのメッセージ送信
-- **StreamizCache**: 確定データの永続化
-- **KeyAttribute**: エンティティキー特定（リフレクション使用）
+ - **IKafkaProducer**: 最終トピックへのメッセージ送信
+ - **StreamizCache**: 確定データの永続化
+ - **KeyExtractor**: `EntityModelBuilder.HasKey()` で指定したキーの取得ヘルパー
 
 ---
 
 ## 注意点
 
-1. **KeyAttribute未定義エンティティ**: HashCode使用でキー生成
+1. **キー指定がないエンティティ**: HashCode使用でキー生成
 2. **メモリ使用量**: RetentionHours設定での自動クリーンアップ
 3. **並行処理**: WindowStateでのlockベース同期制御
 4. **タイマー精度**: デフォルト1秒間隔での確定処理チェック


### PR DESCRIPTION
## Summary
- update core namespace patterns section
- clarify streamiz cache settings
- note pool removal in messaging namespace
- remove KeyAttribute reference from window namespace

## Testing
- `dotnet test Kafka.Ksql.Linq.sln --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_687c1785a2c48327a2a6510a45ab54ef