### PR TITLE
Prevent duplicate group key columns

### DIFF
--- a/tests/Query/Builders/Visitors/SelectExpressionVisitorKeyDuplicateTests.cs
+++ b/tests/Query/Builders/Visitors/SelectExpressionVisitorKeyDuplicateTests.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Kafka.Ksql.Linq.Query.Builders;
+using Kafka.Ksql.Linq.Tests;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Query.Builders.Visitors;
+
+public class SelectExpressionVisitorKeyDuplicateTests
+{
+    [Fact]
+    public void VisitNew_DuplicateGroupKey_IgnoresDuplicate()
+    {
+        Expression<Func<TestEntity, object>> groupExpr = e => e.Id;
+        var groupBuilder = new GroupByClauseBuilder();
+        groupBuilder.Build(groupExpr.Body);
+
+        Expression<Func<IGrouping<int, TestEntity>, object>> select = g => new { g.Key, Dup = g.Key };
+        var visitor = new SelectExpressionVisitor();
+        visitor.Visit(select.Body);
+        var result = visitor.GetResult();
+        Assert.Equal("Id", result);
+    }
+}


### PR DESCRIPTION
## Summary
- update SelectExpressionVisitor to skip duplicate GroupBy key columns
- add tests verifying duplicate keys are removed

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --no-build -v minimal`
- `dotnet test physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687c445ee1c48327bbd2125e388988eb