### PR TITLE
Fix decimal aggregations in physical tests

### DIFF
--- a/docs/changes/20250720_progress.md
+++ b/docs/changes/20250720_progress.md
@@ -16,3 +16,5 @@
 ## 2025-07-20 08:07 JST [assistant]
 - key_value_flow.md と query_to_addasync_sample.md を entityset_to_messaging_story.md のトーンに統一
 - 文体調整とベストプラクティス追記
+## 2025-07-20 10:42 JST [assistant]
+- physicalTests の AMOUNT 列を DOUBLE 型へ変更し、関連テストを更新

--- a/physicalTests/DummyFlagMessageTests.cs
+++ b/physicalTests/DummyFlagMessageTests.cs
@@ -68,7 +68,7 @@ public class DummyFlagMessageTests
         public int CustomerId { get; set; }
         public int Id { get; set; }
         public string? Region { get; set; }
-        public decimal Amount { get; set; }
+        public double Amount { get; set; }
         public bool IsHighPriority { get; set; }
         public int Count { get; set; }
     }
@@ -101,7 +101,7 @@ public class DummyFlagMessageTests
             Headers = new Dictionary<string, object> { ["is_dummy"] = true }
         };
 
-        var entity = new OrderValue { CustomerId = 1, Id = 1, Region = "west", Amount = 10m, IsHighPriority = false, Count = 1 };
+        var entity = new OrderValue { CustomerId = 1, Id = 1, Region = "west", Amount = 10d, IsHighPriority = false, Count = 1 };
         await kp.SendAsync(entity, context);
 
         Assert.Single(producer.Produced);

--- a/physicalTests/DummyFlagSchemaRecognitionTests.cs
+++ b/physicalTests/DummyFlagSchemaRecognitionTests.cs
@@ -23,7 +23,7 @@ public class DummyFlagSchemaRecognitionTests
         public int CustomerId { get; set; }
         public int Id { get; set; }
         public string Region { get; set; } = string.Empty;
-        public decimal Amount { get; set; }
+        public double Amount { get; set; }
         public bool IsHighPriority { get; set; }
         public int Count { get; set; }
     }
@@ -44,13 +44,13 @@ public class DummyFlagSchemaRecognitionTests
     {
         public int? CustomerId { get; set; }
         public string Region { get; set; } = string.Empty;
-        public decimal Amount { get; set; }
+        public double Amount { get; set; }
     }
 
     public class NullableKeyOrder
     {
         public int? CustomerId { get; set; }
-        public decimal Amount { get; set; }
+        public double Amount { get; set; }
     }
 
     public class DummyContext : KsqlContext
@@ -82,15 +82,15 @@ public class DummyFlagSchemaRecognitionTests
             CustomerId = 1,
             Id = 1,
             Region = "east",
-            Amount = 10m,
+            Amount = 10d,
             IsHighPriority = false,
             Count = 1
         }, dummyCtx);
 
         await (await manager.GetProducerAsync<Customer>()).SendAsync(new Customer { Id = 1, Name = "alice" }, dummyCtx);
         await (await manager.GetProducerAsync<EventLog>()).SendAsync(new EventLog { Level = 1, Message = "init" }, dummyCtx);
-        await (await manager.GetProducerAsync<NullableOrder>()).SendAsync(new NullableOrder { CustomerId = 1, Region = "east", Amount = 10m }, dummyCtx);
-        await (await manager.GetProducerAsync<NullableKeyOrder>()).SendAsync(new NullableKeyOrder { CustomerId = 1, Amount = 10m }, dummyCtx);
+        await (await manager.GetProducerAsync<NullableOrder>()).SendAsync(new NullableOrder { CustomerId = 1, Region = "east", Amount = 10d }, dummyCtx);
+        await (await manager.GetProducerAsync<NullableKeyOrder>()).SendAsync(new NullableKeyOrder { CustomerId = 1, Amount = 10d }, dummyCtx);
 
         await Task.Delay(500);
         await ctx.DisposeAsync();

--- a/physicalTests/DynamicKsqlGenerationTests.cs
+++ b/physicalTests/DynamicKsqlGenerationTests.cs
@@ -293,7 +293,7 @@ public class DynamicKsqlGenerationTests
         public int CustomerId { get; set; }
         public int Id { get; set; }
         public string Region { get; set; } = string.Empty;
-        public decimal Amount { get; set; }
+        public double Amount { get; set; }
         public bool IsHighPriority { get; set; }
         public int Count { get; set; }
     }
@@ -314,13 +314,13 @@ public class DynamicKsqlGenerationTests
     {
         public int? CustomerId { get; set; }
         public string Region { get; set; } = string.Empty;
-        public decimal Amount { get; set; }
+        public double Amount { get; set; }
     }
 
     public class NullableKeyOrder
     {
         public int? CustomerId { get; set; }
-        public decimal Amount { get; set; }
+        public double Amount { get; set; }
     }
 
     public class DummyContext : KsqlContext
@@ -342,15 +342,15 @@ public class DynamicKsqlGenerationTests
             CustomerId = 1,
             Id = 1,
             Region = "east",
-            Amount = 10m,
+            Amount = 10d,
             IsHighPriority = false,
             Count = 1
         });
 
         await ctx.Set<Customer>().AddAsync(new Customer { Id = 1, Name = "alice" });
         await ctx.Set<EventLog>().AddAsync(new EventLog { Level = 1, Message = "init" });
-        await ctx.Set<NullableOrder>().AddAsync(new NullableOrder { CustomerId = 1, Region = "east", Amount = 10m });
-        await ctx.Set<NullableKeyOrder>().AddAsync(new NullableKeyOrder { CustomerId = 1, Amount = 10m });
+        await ctx.Set<NullableOrder>().AddAsync(new NullableOrder { CustomerId = 1, Region = "east", Amount = 10d });
+        await ctx.Set<NullableKeyOrder>().AddAsync(new NullableKeyOrder { CustomerId = 1, Amount = 10d });
 
         await Task.Delay(500);
         await ctx.DisposeAsync();

--- a/physicalTests/QueryBuilderExecutionModeTests.cs
+++ b/physicalTests/QueryBuilderExecutionModeTests.cs
@@ -10,7 +10,7 @@ public class QueryBuilderExecutionModeTests
     private class SimpleEntity
     {
         public int Id { get; set; }
-        public decimal Amount { get; set; }
+        public double Amount { get; set; }
     }
 
     [Fact]

--- a/physicalTests/SchemaNameCaseSensitivityTests.cs
+++ b/physicalTests/SchemaNameCaseSensitivityTests.cs
@@ -21,7 +21,7 @@ public class SchemaNameCaseSensitivityTests
         public int CustomerId { get; set; }
         public int Id { get; set; }
         public string Region { get; set; } = string.Empty;
-        public decimal Amount { get; set; }
+        public double Amount { get; set; }
     }
 
     public class OrderWrongCase
@@ -29,7 +29,7 @@ public class SchemaNameCaseSensitivityTests
         public int CustomerId { get; set; }
         public int Id { get; set; }
         public string region { get; set; } = string.Empty; // lowercase r
-        public decimal Amount { get; set; }
+        public double Amount { get; set; }
     }
 
     public class OrderContext : KsqlContext
@@ -63,7 +63,7 @@ public class SchemaNameCaseSensitivityTests
             CustomerId = 1,
             Id = 1,
             Region = "east",
-            Amount = 10m
+            Amount = 10d
         }, dummyCtx);
 
         await Task.Delay(500);

--- a/physicalTests/TestSchema.cs
+++ b/physicalTests/TestSchema.cs
@@ -15,7 +15,7 @@ internal static class TestSchema
             ("CustomerId", "INT"),
             ("Id", "INT"),
             ("Region", "VARCHAR"),
-            ("Amount", $"DECIMAL({DecimalPrecisionConfig.DecimalPrecision}, {DecimalPrecisionConfig.DecimalScale})"),
+            ("Amount", "DOUBLE"),
             ("IsHighPriority", "BOOLEAN"),
             ("Count", "INT")
         },
@@ -33,12 +33,12 @@ internal static class TestSchema
         {
             ("CustomerId", "INT"),
             ("Region", "VARCHAR"),
-            ("Amount", $"DECIMAL({DecimalPrecisionConfig.DecimalPrecision}, {DecimalPrecisionConfig.DecimalScale})")
+            ("Amount", "DOUBLE")
         },
         ["orders_nullable_key"] = new[]
         {
             ("CustomerId", "INT"),
-            ("Amount", $"DECIMAL({DecimalPrecisionConfig.DecimalPrecision}, {DecimalPrecisionConfig.DecimalScale})")
+            ("Amount", "DOUBLE")
         }
     };
 


### PR DESCRIPTION
## Summary
- use DOUBLE for `Amount` columns in integration test schema
- update entity classes and dummy data to use `double`
- record progress log entry

## Testing
- `dotnet test physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687c482bd56483278cbe315c53746a24