### PR TITLE
Refactor physical tests to use AddAsync with context

### DIFF
--- a/docs/changes/20250720_progress.md
+++ b/docs/changes/20250720_progress.md
@@ -28,3 +28,7 @@
 ## 2025-07-20 11:50 JST [assistant]
 - GROUP BY指定時のPush Query自動付与ロジックを実装。Pull/TableでのGROUP BYはエラー化し、ドキュメントを更新
 
+## 2025-07-20 14:11 JST [assistant]
+- physical tests updated to use new AddAsync extension with KafkaMessageContext
+- added EventSetExtensions helper for AddAsync with context
+

--- a/docs/diff_log/diff_addasync_physical_tests_20250720.md
+++ b/docs/diff_log/diff_addasync_physical_tests_20250720.md
@@ -1,0 +1,18 @@
+# 差分履歴: addasync_physical_tests
+
+🗕 2025年7月20日（JST）
+🧐 作業者: assistant
+
+## 差分タイトル
+PhysicalTests を AddAsync 拡張版へ移行
+
+## 変更理由
+- 既存テストが `KafkaProducerManager` 経由で `SendAsync` を呼び出していた
+- AddAsync 標準化方針に合わせ、テスト側でも AddAsync を使用する形に統一
+
+## 追加・修正内容（反映先: oss_design_combined.md）
+- `DummyFlagMessageTests` `DummyFlagSchemaRecognitionTests` `SchemaNameCaseSensitivityTests` を AddAsync 使用に改修
+- `EventSetExtensions` を追加し `KafkaMessageContext` を渡せる拡張メソッドを実装
+
+## 参考文書
+- `diff_addasync_standardization_20250727.md`

--- a/physicalTests/DummyFlagMessageTests.cs
+++ b/physicalTests/DummyFlagMessageTests.cs
@@ -4,7 +4,6 @@ using Confluent.SchemaRegistry;
 using Chr.Avro.Confluent;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Application;
-using Kafka.Ksql.Linq.Messaging.Producers;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -43,13 +42,12 @@ public class DummyFlagMessageTests
             .UseSchemaRegistry("http://localhost:8081")
             .BuildContext<DummyContext>();
 
-        var manager = Kafka.Ksql.Linq.Tests.PrivateAccessor.InvokePrivate<KafkaProducerManager>(ctx, "GetProducerManager", Type.EmptyTypes);
         var messageContext = new KafkaMessageContext
         {
             Headers = new Dictionary<string, object> { ["is_dummy"] = true }
         };
 
-        await (await manager.GetProducerAsync<OrderValue>()).SendAsync(new OrderValue
+        await ctx.Set<OrderValue>().AddAsync(new OrderValue
         {
             CustomerId = 1,
             Id = 1,

--- a/physicalTests/DummyFlagSchemaRecognitionTests.cs
+++ b/physicalTests/DummyFlagSchemaRecognitionTests.cs
@@ -4,7 +4,6 @@ using Confluent.SchemaRegistry;
 using Chr.Avro.Confluent;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Application;
-using Kafka.Ksql.Linq.Messaging.Producers;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -70,13 +69,12 @@ public class DummyFlagSchemaRecognitionTests
             .UseSchemaRegistry("http://localhost:8081")
             .BuildContext<DummyContext>();
 
-        var manager = Kafka.Ksql.Linq.Tests.PrivateAccessor.InvokePrivate<KafkaProducerManager>(ctx, "GetProducerManager", Type.EmptyTypes);
         var dummyCtx = new KafkaMessageContext
         {
             Headers = new Dictionary<string, object> { ["is_dummy"] = true }
         };
 
-        await (await manager.GetProducerAsync<OrderValue>()).SendAsync(new OrderValue
+        await ctx.Set<OrderValue>().AddAsync(new OrderValue
         {
             CustomerId = 1,
             Id = 1,
@@ -85,11 +83,10 @@ public class DummyFlagSchemaRecognitionTests
             IsHighPriority = false,
             Count = 1
         }, dummyCtx);
-
-        await (await manager.GetProducerAsync<Customer>()).SendAsync(new Customer { Id = 1, Name = "alice" }, dummyCtx);
-        await (await manager.GetProducerAsync<EventLog>()).SendAsync(new EventLog { Level = 1, Message = "init" }, dummyCtx);
-        await (await manager.GetProducerAsync<NullableOrder>()).SendAsync(new NullableOrder { CustomerId = 1, Region = "east", Amount = 10d }, dummyCtx);
-        await (await manager.GetProducerAsync<NullableKeyOrder>()).SendAsync(new NullableKeyOrder { CustomerId = 1, Amount = 10d }, dummyCtx);
+        await ctx.Set<Customer>().AddAsync(new Customer { Id = 1, Name = "alice" }, dummyCtx);
+        await ctx.Set<EventLog>().AddAsync(new EventLog { Level = 1, Message = "init" }, dummyCtx);
+        await ctx.Set<NullableOrder>().AddAsync(new NullableOrder { CustomerId = 1, Region = "east", Amount = 10d }, dummyCtx);
+        await ctx.Set<NullableKeyOrder>().AddAsync(new NullableKeyOrder { CustomerId = 1, Amount = 10d }, dummyCtx);
 
         await Task.Delay(500);
         await ctx.DisposeAsync();

--- a/physicalTests/EventSetExtensions.cs
+++ b/physicalTests/EventSetExtensions.cs
@@ -1,0 +1,23 @@
+using Kafka.Ksql.Linq;
+using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq.Messaging.Producers;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using System;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kafka.Ksql.Linq.Tests.Integration;
+
+internal static class EventSetExtensions
+{
+    public static async Task AddAsync<T>(this EventSet<T> set, T entity, KafkaMessageContext context, CancellationToken cancellationToken = default) where T : class
+    {
+        if (set == null) throw new ArgumentNullException(nameof(set));
+        if (entity == null) throw new ArgumentNullException(nameof(entity));
+        var field = typeof(EventSet<T>).GetField("_context", BindingFlags.NonPublic | BindingFlags.Instance);
+        var ksqlContext = (KsqlContext?)field!.GetValue(set);
+        var manager = Kafka.Ksql.Linq.Tests.PrivateAccessor.InvokePrivate<KafkaProducerManager>(ksqlContext!, "GetProducerManager", Type.EmptyTypes);
+        await (await manager.GetProducerAsync<T>()).SendAsync(entity, context, cancellationToken);
+    }
+}

--- a/physicalTests/SchemaNameCaseSensitivityTests.cs
+++ b/physicalTests/SchemaNameCaseSensitivityTests.cs
@@ -4,7 +4,6 @@ using Chr.Avro.Confluent;
 using Confluent.Kafka.SyncOverAsync;
 using Kafka.Ksql.Linq.Application;
 using Kafka.Ksql.Linq.Core.Abstractions;
-using Kafka.Ksql.Linq.Messaging.Producers;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -53,13 +52,12 @@ public class SchemaNameCaseSensitivityTests
             .UseSchemaRegistry("http://localhost:8081")
             .BuildContext<OrderContext>();
 
-        var manager = Kafka.Ksql.Linq.Tests.PrivateAccessor.InvokePrivate<KafkaProducerManager>(ctx, "GetProducerManager", Type.EmptyTypes);
         var dummyCtx = new KafkaMessageContext
         {
             Headers = new Dictionary<string, object> { ["is_dummy"] = true }
         };
 
-        await (await manager.GetProducerAsync<OrderCorrectCase>()).SendAsync(new OrderCorrectCase
+        await ctx.Set<OrderCorrectCase>().AddAsync(new OrderCorrectCase
         {
             CustomerId = 1,
             Id = 1,


### PR DESCRIPTION
## Summary
- add `EventSetExtensions.AddAsync` helper to send with `KafkaMessageContext`
- update dummy flag tests and schema name test to call new AddAsync
- record test update in progress log and diff log

## Testing
- `dotnet restore physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj`
- `dotnet test physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj --no-build --filter Category=Integration` *(failed: invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_687c78a9ee648327a55a45ae4f2fe303