### PR TITLE
Add Kafka header support and typed builder factories

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ class Program
             Amount = 10m
         };
 
-        await context.Set<ManualCommitOrder>().AddAsync(order);
+        await context.Set<ManualCommitOrder>().AddAsync(
+            order,
+            headers: new Dictionary<string, string> { ["is_dummy"] = "true" });
         await Task.Delay(500);
 
         await context.Set<ManualCommitOrder>().ForEachAsync(async (IManualCommitMessage<ManualCommitOrder> msg) =>
@@ -102,6 +104,13 @@ class Program
     }
 }
 
+
+
+```
+
+// Build a Consumer with matching serializers automatically
+var consumer = context.CreateConsumerBuilder<ManualCommitOrder>()
+    .Build();
 
 ```
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -136,7 +136,7 @@ var ctx = new MyKsqlContext(options);
 var mapping = ctx.MappingManager;
 var entity = new Order { Id = 1, Amount = 100 };
 var (key, value) = mapping.ExtractKeyValue(entity);
-await ctx.AddAsync(entity);
+await ctx.AddAsync(entity, headers: new Dictionary<string, string> { ["is_dummy"] = "true" });
 ```
 #### ベストプラクティス
 - エンティティ登録は `OnModelCreating` 内で一括定義する。

--- a/docs/architecture/key_value_flow.md
+++ b/docs/architecture/key_value_flow.md
@@ -124,7 +124,7 @@ var ksql = builder.Build(query);
 var entity = new User { Id = 1, Name = "Alice" };
 var parts = mapping.ExtractKeyParts(entity);
 var key = KeyExtractor.BuildTypedKey(parts);
-await ctx.AddAsync(entity);
+await ctx.AddAsync(entity, headers: new Dictionary<string, string> { ["is_dummy"] = "true" });
 ```
 
 複合キーは `List<(string KeyName, Type KeyType, string Value)>` として抽出し、送信時に `BuildTypedKey` で型変換する方式へ移行しました。既存の `ExtractKeyValue` は互換APIとして残ります。

--- a/docs/changes/20250731_progress.md
+++ b/docs/changes/20250731_progress.md
@@ -85,3 +85,7 @@
 - Producer/Consumer の型情報自動展開APIを追加
 - ドキュメントとテストを更新
 
+## 2025-07-20 15:34 JST [assistant]
+- SendEntityAsync 変更に追従して物理テストを修正
+- 単体・統合テストを実行しビルドエラーを解消
+

--- a/docs/changes/20250731_progress.md
+++ b/docs/changes/20250731_progress.md
@@ -80,3 +80,8 @@
 ## 2025-07-20 11:53 JST [assistant]
 - MIN/MAX stream-only aggregation detection implemented. CREATE TABLE with such functions now throws error; docs updated.
 
+## 2025-07-20 14:20 JST [assistant]
+- AddAsync/SendAsync で任意のKafkaヘッダーを指定できるオプションを実装
+- Producer/Consumer の型情報自動展開APIを追加
+- ドキュメントとテストを更新
+

--- a/docs/diff_log/diff_kafka_headers_factory_20250720.md
+++ b/docs/diff_log/diff_kafka_headers_factory_20250720.md
@@ -1,0 +1,20 @@
+# 差分履歴: kafka_headers_factory
+
+🗕 2025年7月20日（JST）
+🧐 作業者: assistant
+
+## 差分タイトル
+AddAsync/SendAsync ヘッダー指定と型安全Factory追加
+
+## 変更理由
+- Kafka 送信時に任意のヘッダーを付与できるようにするため
+- Producer/Consumer の型情報を自動展開し、同一型のインスタンスを生成するAPIを提供するため
+
+## 追加・修正内容（反映先: oss_design_combined.md）
+- `AddAsync`/`SendAsync` に `Dictionary<string,string>` ヘッダー引数を追加
+- `KafkaProducerManager.CreateProducerBuilder<T>` / `KafkaConsumerManager.CreateConsumerBuilder<T>` 実装
+- `KsqlContext` から上記ファクトリを取得できるメソッドを公開
+- README とドキュメントのサンプルコードをヘッダー付きに更新
+
+## 参考文書
+- `docs_advanced_rules.md` テスト方針セクション

--- a/docs/structure/naruse/key_value_flow_naruse.md
+++ b/docs/structure/naruse/key_value_flow_naruse.md
@@ -52,7 +52,7 @@ var schema = QueryAnalyzer.AnalyzeQuery<User, User>(q => q.Where(u => u.Id == 1)
 var query = context.Set<User>().Where(u => u.Id == 1);
 var entity = new User { Id = 1, Name = "Alice" };
 var (key, value) = PocoMapper.ToKeyValue(entity, schema);
-await context.AddAsync(entity);
+await context.AddAsync(entity, headers: new Dictionary<string, string> { ["is_dummy"] = "true" });
 ```
 
 上記のように `Query` から生成したエンティティを `PocoMapper` で key/value に変換し、`KsqlContext` 経由で Kafka へ送信します。

--- a/docs/structure/shared/key_value_flow.md
+++ b/docs/structure/shared/key_value_flow.md
@@ -126,7 +126,7 @@ var ksql = builder.Build(query);
 var entity = new User { Id = 1, Name = "Alice" };
 var parts = mapping.ExtractKeyParts(entity);
 var key = KeyExtractor.BuildTypedKey(parts);
-await ctx.AddAsync(entity);
+await ctx.AddAsync(entity, headers: new Dictionary<string, string> { ["is_dummy"] = "true" });
 ```
 
 複合キーは `List<(string KeyName, Type KeyType, string Value)>` として抽出し、送信時に `BuildTypedKey` で型変換する方式へ移行しました。既存の `ExtractKeyValue` は互換APIとして残ります。

--- a/src/Cache/Core/ReadCachedEntitySet.cs
+++ b/src/Cache/Core/ReadCachedEntitySet.cs
@@ -43,9 +43,9 @@ internal class ReadCachedEntitySet<T> : IEntitySet<T> where T : class
         return await Task.FromResult(all);
     }
 
-    public Task AddAsync(T entity, CancellationToken cancellationToken = default)
+    public Task AddAsync(T entity, Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default)
     {
-        return _baseSet.AddAsync(entity, cancellationToken);
+        return _baseSet.AddAsync(entity, headers, cancellationToken);
     }
 
     public Task RemoveAsync(T entity, CancellationToken cancellationToken = default)

--- a/src/Core/Abstractions/IEntitySet.cs
+++ b/src/Core/Abstractions/IEntitySet.cs
@@ -12,7 +12,7 @@ namespace Kafka.Ksql.Linq.Core.Abstractions;
 public interface IEntitySet<T> : IAsyncEnumerable<T> where T : class
 {
     // Producer operations
-    Task AddAsync(T entity, CancellationToken cancellationToken = default);
+    Task AddAsync(T entity, Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default);
     Task RemoveAsync(T entity, CancellationToken cancellationToken = default);
 
     // Consumer operations

--- a/src/Core/Window/WindowAggregatedEntitySet.cs
+++ b/src/Core/Window/WindowAggregatedEntitySet.cs
@@ -61,7 +61,7 @@ internal class WindowAggregatedEntitySet<TSource, TKey, TResult> : IEntitySet<TR
     }
 
     // ✅ IEntitySet<TResult> インターフェース実装
-    public async Task AddAsync(TResult entity, CancellationToken cancellationToken = default)
+    public async Task AddAsync(TResult entity, Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default)
     {
         await Task.CompletedTask;
         throw new NotSupportedException("Cannot add entities to a window aggregated result set");

--- a/src/Core/Window/WindowFilteredEntitySet.cs
+++ b/src/Core/Window/WindowFilteredEntitySet.cs
@@ -58,7 +58,7 @@ internal class WindowFilteredEntitySet<T> : IEntitySet<T> where T : class
         }
     }
 
-    public Task AddAsync(T entity, CancellationToken cancellationToken = default) => _baseSet.AddAsync(entity, cancellationToken);
+    public Task AddAsync(T entity, Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default) => _baseSet.AddAsync(entity, headers, cancellationToken);
     public Task RemoveAsync(T entity, CancellationToken cancellationToken = default) => _baseSet.RemoveAsync(entity, cancellationToken);
     public string GetTopicName() => _baseSet.GetTopicName();
     public EntityModel GetEntityModel() => _baseSet.GetEntityModel();

--- a/src/Core/Window/WindowedEntitySet.cs
+++ b/src/Core/Window/WindowedEntitySet.cs
@@ -103,9 +103,9 @@ internal class WindowedEntitySet<T> : IWindowedEntitySet<T> where T : class
     }
 
     // ✅ IEntitySet<T> インターフェース実装 - ベースEntitySetに委譲
-    public async Task AddAsync(T entity, CancellationToken cancellationToken = default)
+    public async Task AddAsync(T entity, Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default)
     {
-        await _baseEntitySet.AddAsync(entity, cancellationToken);
+        await _baseEntitySet.AddAsync(entity, headers, cancellationToken);
     }
 
     public Task RemoveAsync(T entity, CancellationToken cancellationToken = default)

--- a/src/EventSet.cs
+++ b/src/EventSet.cs
@@ -106,17 +106,17 @@ public abstract class EventSet<T> : IEntitySet<T> where T : class
     /// <summary>
     /// ABSTRACT: Producer functionality - implemented in derived classes
     /// </summary>
-    protected abstract Task SendEntityAsync(T entity, CancellationToken cancellationToken);
+    protected abstract Task SendEntityAsync(T entity, Dictionary<string, string>? headers, CancellationToken cancellationToken);
 
     /// <summary>
     /// IEntitySet<T> implementation: producer operations
     /// </summary>
-    public virtual async Task AddAsync(T entity, CancellationToken cancellationToken = default)
+    public virtual async Task AddAsync(T entity, Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default)
     {
         if (entity == null)
             throw new ArgumentNullException(nameof(entity));
 
-        await SendEntityAsync(entity, cancellationToken);
+        await SendEntityAsync(entity, headers, cancellationToken);
     }
 
     public virtual Task RemoveAsync(T entity, CancellationToken cancellationToken = default)
@@ -498,7 +498,7 @@ internal class MappedEventSet<T> : EventSet<T> where T : class
     /// <summary>
     /// Data after Map cannot be sent via Producer
     /// </summary>
-    protected override Task SendEntityAsync(T entity, CancellationToken cancellationToken)
+    protected override Task SendEntityAsync(T entity, Dictionary<string, string>? headers, CancellationToken cancellationToken)
     {
         throw new NotSupportedException(
             $"MappedEventSet<{typeof(T).Name}> does not support AddAsync operations. " +

--- a/src/Query/Abstractions/IEventSet.cs
+++ b/src/Query/Abstractions/IEventSet.cs
@@ -15,7 +15,7 @@ namespace Kafka.Ksql.Linq.Query.Abstractions;
 internal interface IEventSet<T> : IQueryable<T>, IAsyncEnumerable<T> where T : class
 {
     // Core Operations
-    Task AddAsync(T entity, CancellationToken cancellationToken = default);
+    Task AddAsync(T entity, Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default);
     Task AddRangeAsync(IEnumerable<T> entities, CancellationToken cancellationToken = default);
 
     // Query Operations  

--- a/src/Query/Linq/JoinableEntitySet.cs
+++ b/src/Query/Linq/JoinableEntitySet.cs
@@ -22,9 +22,9 @@ public class JoinableEntitySet<T> : IEntitySet<T>, IJoinableEntitySet<T> where T
     }
 
     // ✅ IEntitySet<T>の必須実装
-    public async Task AddAsync(T entity, CancellationToken cancellationToken = default)
+    public async Task AddAsync(T entity, Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default)
     {
-        await _baseEntitySet.AddAsync(entity, cancellationToken);
+        await _baseEntitySet.AddAsync(entity, headers, cancellationToken);
     }
 
     public async Task RemoveAsync(T entity, CancellationToken cancellationToken = default)

--- a/src/Query/Linq/TypedJoinResultEntitySet.cs
+++ b/src/Query/Linq/TypedJoinResultEntitySet.cs
@@ -45,7 +45,7 @@ internal class TypedJoinResultEntitySet<TOuter, TInner, TResult> : IEntitySet<TR
         return new List<TResult>();
     }
 
-    public Task AddAsync(TResult entity, CancellationToken cancellationToken = default)
+    public Task AddAsync(TResult entity, Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default)
     {
         throw new NotSupportedException("Cannot add entities to a join result set");
     }

--- a/src/Query/Linq/TypedThreeWayJoinResultEntitySet.cs
+++ b/src/Query/Linq/TypedThreeWayJoinResultEntitySet.cs
@@ -55,7 +55,7 @@ internal class TypedThreeWayJoinResultEntitySet<TOuter, TInner, TThird, TResult>
         return new List<TResult>();
     }
 
-    public Task AddAsync(TResult entity, CancellationToken cancellationToken = default)
+    public Task AddAsync(TResult entity, Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default)
     {
         throw new NotSupportedException("Cannot add entities to a three-way join result set");
     }

--- a/tests/Application/EventSetWithServicesSendTests.cs
+++ b/tests/Application/EventSetWithServicesSendTests.cs
@@ -73,7 +73,7 @@ public class EventSetWithServicesSendTests
         dict[typeof(Sample)] = stub;
 
         var set = new EventSetWithServices<Sample>(ctx, CreateModel());
-        await set.AddAsync(new Sample(), CancellationToken.None);
+        await set.AddAsync(new Sample(), null, CancellationToken.None);
         Assert.True(stub.Sent);
     }
 }

--- a/tests/Core/Window/WindowAggregatedEntitySetTests.cs
+++ b/tests/Core/Window/WindowAggregatedEntitySetTests.cs
@@ -30,7 +30,7 @@ public class WindowAggregatedEntitySetTests
             _context = context;
             _model = model;
         }
-        public Task AddAsync(T entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task AddAsync(T entity, Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task RemoveAsync(T entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<T>());
         public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/tests/Core/Window/WindowCollectionTests.cs
+++ b/tests/Core/Window/WindowCollectionTests.cs
@@ -30,7 +30,7 @@ public class WindowCollectionTests
             _context = context;
             _model = model;
         }
-        public Task AddAsync(T entity, CancellationToken cancellationToken = default) { Items.Add(entity); return Task.CompletedTask; }
+        public Task AddAsync(T entity, Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default) { Items.Add(entity); return Task.CompletedTask; }
         public Task RemoveAsync(T entity, CancellationToken cancellationToken = default) { Items.Remove(entity); return Task.CompletedTask; }
         public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<T>(Items));
         public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.WhenAll(Items.Select(action));

--- a/tests/Core/Window/WindowedEntitySetTests.cs
+++ b/tests/Core/Window/WindowedEntitySetTests.cs
@@ -30,7 +30,7 @@ public class WindowedEntitySetTests
             _context = context;
             _model = model;
         }
-        public Task AddAsync(T entity, CancellationToken cancellationToken = default) { Items.Add(entity); return Task.CompletedTask; }
+        public Task AddAsync(T entity, Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default) { Items.Add(entity); return Task.CompletedTask; }
         public Task RemoveAsync(T entity, CancellationToken cancellationToken = default) { Items.Remove(entity); return Task.CompletedTask; }
         public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<T>(Items));
         public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.WhenAll(Items.Select(action));

--- a/tests/EventSetCreateMessageContextTests.cs
+++ b/tests/EventSetCreateMessageContextTests.cs
@@ -26,7 +26,7 @@ public class EventSetCreateMessageContextTests
         {
         }
 
-        protected override Task SendEntityAsync(TestEntity entity, CancellationToken cancellationToken) => Task.CompletedTask;
+        protected override Task SendEntityAsync(TestEntity entity, Dictionary<string, string>? headers, CancellationToken cancellationToken) => Task.CompletedTask;
 
         public override async IAsyncEnumerator<TestEntity> GetAsyncEnumerator(CancellationToken cancellationToken = default)
         {

--- a/tests/EventSetLimitExtensionsTests.cs
+++ b/tests/EventSetLimitExtensionsTests.cs
@@ -43,7 +43,7 @@ public class EventSetLimitExtensionsTests
             _items = items.ToList();
             _model.BarTimeSelector = (Expression<Func<RateCandle, DateTime>>)(x => x.BarTime);
         }
-        public Task AddAsync(RateCandle entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task AddAsync(RateCandle entity, Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task<List<RateCandle>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(_items.ToList());
         public Task ForEachAsync(Func<RateCandle, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.WhenAll(_items.Select(action));
         public string GetTopicName() => _model.TopicName!;

--- a/tests/EventSetMapTests.cs
+++ b/tests/EventSetMapTests.cs
@@ -41,7 +41,7 @@ public class EventSetMapTests
             _items = items;
         }
 
-        protected override Task SendEntityAsync(Sample entity, CancellationToken cancellationToken) => Task.CompletedTask;
+        protected override Task SendEntityAsync(Sample entity, Dictionary<string, string>? headers, CancellationToken cancellationToken) => Task.CompletedTask;
 
         public override async IAsyncEnumerator<Sample> GetAsyncEnumerator(CancellationToken cancellationToken = default)
         {

--- a/tests/EventSetTests.cs
+++ b/tests/EventSetTests.cs
@@ -30,7 +30,7 @@ public class EventSetTests
             _items = items;
         }
 
-        protected override Task SendEntityAsync(TestEntity entity, CancellationToken cancellationToken)
+        protected override Task SendEntityAsync(TestEntity entity, Dictionary<string, string>? headers, CancellationToken cancellationToken)
         {
             Sent = true;
             return Task.CompletedTask;

--- a/tests/EventSetWithRetryTests.cs
+++ b/tests/EventSetWithRetryTests.cs
@@ -48,7 +48,7 @@ public class EventSetWithRetryTests
             return new TestSet(_items, context, model, errorCtx, dlq);
         }
 
-        protected override Task SendEntityAsync(TestEntity entity, CancellationToken cancellationToken)
+        protected override Task SendEntityAsync(TestEntity entity, Dictionary<string, string>? headers, CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }

--- a/tests/Extensions/ScheduleWindowBuilderTests.cs
+++ b/tests/Extensions/ScheduleWindowBuilderTests.cs
@@ -116,7 +116,7 @@ public class ScheduleWindowBuilderTests
         public Type ElementType => _query.ElementType;
         public Expression Expression => _query.Expression;
         public IQueryProvider Provider => _query.Provider;
-        public Task AddAsync(T entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task AddAsync(T entity, Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task RemoveAsync(T entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(_query.ToList());
         public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.WhenAll(_query.Select(action));

--- a/tests/Extensions/WindowFilterExtensionsTests.cs
+++ b/tests/Extensions/WindowFilterExtensionsTests.cs
@@ -22,7 +22,7 @@ public class WindowFilterExtensionsTests
             _model = model;
         }
         public void AddItem(T item) => _items.Add(item);
-        public Task AddAsync(T entity, CancellationToken cancellationToken = default) { _items.Add(entity); return Task.CompletedTask; }
+        public Task AddAsync(T entity, Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default) { _items.Add(entity); return Task.CompletedTask; }
         public Task RemoveAsync(T entity, CancellationToken cancellationToken = default) { _items.Remove(entity); return Task.CompletedTask; }
         public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<T>(_items));
         public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.WhenAll(_items.Select(action));

--- a/tests/ForEachAsyncErrorHandlingTests.cs
+++ b/tests/ForEachAsyncErrorHandlingTests.cs
@@ -28,7 +28,7 @@ public class ForEachAsyncErrorHandlingTests
             _items = items;
         }
 
-        protected override Task SendEntityAsync(TestEntity entity, CancellationToken cancellationToken) => Task.CompletedTask;
+        protected override Task SendEntityAsync(TestEntity entity, Dictionary<string, string>? headers, CancellationToken cancellationToken) => Task.CompletedTask;
 
         private class FaultyEnumerator : IAsyncEnumerator<TestEntity>
         {

--- a/tests/ManualCommitTests.cs
+++ b/tests/ManualCommitTests.cs
@@ -31,7 +31,7 @@ public class ManualCommitTests
             _items = items;
         }
 
-        protected override Task SendEntityAsync(TestEntity entity, CancellationToken cancellationToken)
+        protected override Task SendEntityAsync(TestEntity entity, Dictionary<string, string>? headers, CancellationToken cancellationToken)
             => Task.CompletedTask;
 
         public override async IAsyncEnumerator<TestEntity> GetAsyncEnumerator(CancellationToken cancellationToken = default)

--- a/tests/Messaging/KafkaProducerManagerDisposeTests.cs
+++ b/tests/Messaging/KafkaProducerManagerDisposeTests.cs
@@ -105,7 +105,7 @@ public class KafkaProducerManagerDisposeTests
         var stub = new StubProducer<Sample>();
         producers[typeof(Sample)] = stub;
 
-        await manager.SendAsync(new Sample());
+        await manager.SendAsync(new Sample(), null);
         Assert.True(stub.Sent);
 
         manager.Dispose();

--- a/tests/Query/JoinableEntitySetTests.cs
+++ b/tests/Query/JoinableEntitySetTests.cs
@@ -25,7 +25,7 @@ public class JoinableEntitySetTests
     private class DummySet<T> : IEntitySet<T> where T : class
     {
         private readonly IKsqlContext _context = new DummyContext();
-        public Task AddAsync(T entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task AddAsync(T entity, Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task RemoveAsync(T entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<T>());
         public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/tests/Query/TypedJoinResultEntitySetTests.cs
+++ b/tests/Query/TypedJoinResultEntitySetTests.cs
@@ -24,7 +24,7 @@ public class TypedJoinResultEntitySetTests
     private class DummySet<T> : IEntitySet<T> where T : class
     {
         private readonly IKsqlContext _context = new DummyContext();
-        public Task AddAsync(T entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task AddAsync(T entity, Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task RemoveAsync(T entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<T>());
         public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/tests/RetryReadyChainTests.cs
+++ b/tests/RetryReadyChainTests.cs
@@ -27,7 +27,7 @@ public class RetryReadyChainTests
     {
         public ErrorHandlingPolicy? LastPolicy { get; private set; }
         public TestSet() : base(new DummyContext(), CreateModel()) { }
-        protected override Task SendEntityAsync(TestEntity entity, CancellationToken cancellationToken) => Task.CompletedTask;
+        protected override Task SendEntityAsync(TestEntity entity, Dictionary<string, string>? headers, CancellationToken cancellationToken) => Task.CompletedTask;
         public override async IAsyncEnumerator<TestEntity> GetAsyncEnumerator(CancellationToken cancellationToken = default) { await Task.CompletedTask; yield break; }
         internal override EventSet<TestEntity> WithErrorPolicy(ErrorHandlingPolicy policy) { LastPolicy = policy; return this; }
     }


### PR DESCRIPTION
## Summary
- allow passing custom headers via `AddAsync` and `SendAsync`
- expose producer/consumer builder factories with automatic serializers
- update docs and samples for headers and builder usage
- adjust tests for new method signatures

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687c7bcf91888327bdb72a43d3b8fdbd