### PR TITLE
Resolve test warnings

### DIFF
--- a/docs/changes/20250720_progress.md
+++ b/docs/changes/20250720_progress.md
@@ -32,3 +32,6 @@
 - physical tests updated to use new AddAsync extension with KafkaMessageContext
 - added EventSetExtensions helper for AddAsync with context
 
+## 2025-07-20 15:42 JST [迅人]
+- テスト警告を解消するため各ファイルに #nullable enable を追加し、重複usingを削除
+- 進捗ログを追記

--- a/docs/changes/20250720_progress.md
+++ b/docs/changes/20250720_progress.md
@@ -35,3 +35,7 @@
 ## 2025-07-20 15:42 JST [迅人]
 - テスト警告を解消するため各ファイルに #nullable enable を追加し、重複usingを削除
 - 進捗ログを追記
+
+## 2025-07-20 16:24 JST [迅人]
+- KafkaProducer tombstone送信時のnull許容警告を修正
+- Integrationテストで発生していたnullable警告を一部解消

--- a/physicalTests/DummyFlagMessageTests.cs
+++ b/physicalTests/DummyFlagMessageTests.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
+#nullable enable
 namespace Kafka.Ksql.Linq.Tests.Integration;
 
 public class DummyFlagMessageTests

--- a/physicalTests/SchemaNameCaseSensitivityTests.cs
+++ b/physicalTests/SchemaNameCaseSensitivityTests.cs
@@ -72,7 +72,7 @@ public class SchemaNameCaseSensitivityTests
                 throw new NotSupportedException();
             }
 
-            protected override async Task SendEntityAsync(OrderWrongCase entity, CancellationToken cancellationToken)
+            protected override async Task SendEntityAsync(OrderWrongCase entity, Dictionary<string, string>? headers, CancellationToken cancellationToken)
             {
                 var config = new ProducerConfig { BootstrapServers = "localhost:9093" };
                 using var schema = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = "http://localhost:8081" });

--- a/src/Messaging/Producers/Core/KafkaProducer.cs
+++ b/src/Messaging/Producers/Core/KafkaProducer.cs
@@ -99,10 +99,10 @@ internal class KafkaProducer<T> : IKafkaProducer<T> where T : class
 
         try
         {
-            var kafkaMessage = new Message<object, object?>
+            var kafkaMessage = new Message<object, object>
             {
                 Key = key,
-                Value = null,
+                Value = null!,
                 Headers = BuildHeaders(context),
                 Timestamp = new Timestamp(DateTime.UtcNow)
             };

--- a/tests/Core/Window/WindowAggregatedEntitySetTests.cs
+++ b/tests/Core/Window/WindowAggregatedEntitySetTests.cs
@@ -8,6 +8,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests.Core.Window;
 
 public class WindowAggregatedEntitySetTests

--- a/tests/Core/Window/WindowCollectionTests.cs
+++ b/tests/Core/Window/WindowCollectionTests.cs
@@ -7,6 +7,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests.Core.Window;
 
 public class WindowCollectionTests

--- a/tests/Core/Window/WindowedEntitySetTests.cs
+++ b/tests/Core/Window/WindowedEntitySetTests.cs
@@ -7,6 +7,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests.Core.Window;
 
 public class WindowedEntitySetTests

--- a/tests/EventSetLimitExtensionsTests.cs
+++ b/tests/EventSetLimitExtensionsTests.cs
@@ -9,6 +9,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests;
 
 public class EventSetLimitExtensionsTests

--- a/tests/EventSetMapTests.cs
+++ b/tests/EventSetMapTests.cs
@@ -7,6 +7,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests;
 
 public class EventSetMapTests

--- a/tests/EventSetTests.cs
+++ b/tests/EventSetTests.cs
@@ -7,6 +7,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests;
 
 public class EventSetTests

--- a/tests/EventSetWithRetryTests.cs
+++ b/tests/EventSetWithRetryTests.cs
@@ -2,7 +2,6 @@ using Kafka.Ksql.Linq.Core.Modeling;
 using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Messaging.Internal;
-using Kafka.Ksql.Linq.Core.Abstractions;
 using System;
 using System.Collections.Generic;
 using System.Reflection;

--- a/tests/Extensions/ScheduleWindowBuilderTests.cs
+++ b/tests/Extensions/ScheduleWindowBuilderTests.cs
@@ -11,6 +11,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests.Extensions;
 
 public class ScheduleWindowBuilderTests

--- a/tests/Extensions/WindowFilterExtensionsTests.cs
+++ b/tests/Extensions/WindowFilterExtensionsTests.cs
@@ -8,6 +8,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests.Extensions;
 
 public class WindowFilterExtensionsTests

--- a/tests/ForEachAsyncErrorHandlingTests.cs
+++ b/tests/ForEachAsyncErrorHandlingTests.cs
@@ -7,6 +7,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests;
 
 public class ForEachAsyncErrorHandlingTests

--- a/tests/ManualCommitTests.cs
+++ b/tests/ManualCommitTests.cs
@@ -7,6 +7,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests;
 
 public class ManualCommitTests

--- a/tests/Mapping/AddAsyncSampleFlowTests.cs
+++ b/tests/Mapping/AddAsyncSampleFlowTests.cs
@@ -19,6 +19,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests.Mapping;
 
 public class AddAsyncSampleFlowTests

--- a/tests/Mapping/AutomaticQueryFlowTests.cs
+++ b/tests/Mapping/AutomaticQueryFlowTests.cs
@@ -18,6 +18,8 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using Xunit;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests.Mapping;
 
 public class AutomaticQueryFlowTests

--- a/tests/Mapping/FullAutoQueryFlowTests.cs
+++ b/tests/Mapping/FullAutoQueryFlowTests.cs
@@ -19,6 +19,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Xunit;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests.Mapping;
 
 public class FullAutoQueryFlowTests

--- a/tests/Mapping/PocoMapperTests.cs
+++ b/tests/Mapping/PocoMapperTests.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using System.Reflection;
 using Xunit;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests.Mapping;
 
 public class PocoMapperTests

--- a/tests/Query/JoinableEntitySetTests.cs
+++ b/tests/Query/JoinableEntitySetTests.cs
@@ -9,6 +9,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests.Query;
 
 public class JoinableEntitySetTests

--- a/tests/Query/Pipeline/DDLQueryGeneratorTests.cs
+++ b/tests/Query/Pipeline/DDLQueryGeneratorTests.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Query.Pipeline;
-using Kafka.Ksql.Linq.Core.Modeling;
 using Xunit;
 using System.IO;
 namespace Kafka.Ksql.Linq.Tests.Query.Pipeline;

--- a/tests/Query/TypedJoinResultEntitySetTests.cs
+++ b/tests/Query/TypedJoinResultEntitySetTests.cs
@@ -8,6 +8,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests.Query;
 
 public class TypedJoinResultEntitySetTests


### PR DESCRIPTION
## Summary
- enable nullable warnings in many tests
- remove duplicate usings from test files
- log progress for today

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_687c8f3cd7f88327bd2f663ee2673d27