### PR TITLE
Fix context usage in physical tests

### DIFF
--- a/docs/changes/20250720_progress.md
+++ b/docs/changes/20250720_progress.md
@@ -49,3 +49,7 @@
 
 ## 2025-07-20 12:16 JST [assistant]
 - removed obsolete Consumer_SkipsDummyMessages integration test
+
+## 2025-07-20 22:16 JST [shion]
+- physicalTests now create context subclasses using KafkaContextOptions
+- KafkaContextOptions enhanced with BootstrapServers and SchemaRegistryUrl

--- a/physicalTests/KsqlSyntax/DynamicKsqlGenerationTests.cs
+++ b/physicalTests/KsqlSyntax/DynamicKsqlGenerationTests.cs
@@ -3,6 +3,7 @@ using Kafka.Ksql.Linq.Core.Modeling;
 using Kafka.Ksql.Linq.Query.Pipeline;
 using Kafka.Ksql.Linq.Query.Abstractions;
 using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq.Core.Context;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -333,6 +334,8 @@ public class DynamicKsqlGenerationTests
 
     public class DummyContext : KsqlContext
     {
+        public DummyContext() : base() { }
+        public DummyContext(KafkaContextOptions options) : base(options) { }
         protected override void OnModelCreating(IModelBuilder modelBuilder)
         {
             DynamicKsqlGenerationTests.ConfigureModel(modelBuilder);
@@ -341,9 +344,13 @@ public class DynamicKsqlGenerationTests
 
     private async Task ProduceDummyRecordsAsync()
     {
-        var ctx = KsqlContextBuilder.Create()
-            .UseSchemaRegistry("http://localhost:8081")
-            .BuildContext<DummyContext>();
+        var options = new KafkaContextOptions
+        {
+            BootstrapServers = "localhost:9093",
+            SchemaRegistryUrl = "http://localhost:8081"
+        };
+
+        await using var ctx = new DummyContext(options);
 
         await ctx.Set<OrderValue>().AddAsync(new OrderValue
         {

--- a/physicalTests/OssSamples/DummyFlagMessageTests.cs
+++ b/physicalTests/OssSamples/DummyFlagMessageTests.cs
@@ -1,5 +1,6 @@
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq.Core.Context;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -23,6 +24,8 @@ public class DummyFlagMessageTests
 
     public class DummyContext : KsqlContext
     {
+        public DummyContext() : base() { }
+        public DummyContext(KafkaContextOptions options) : base(options) { }
         protected override void OnModelCreating(IModelBuilder modelBuilder)
         {
             modelBuilder.Entity<OrderValue>().WithTopic("orders");
@@ -35,9 +38,13 @@ public class DummyFlagMessageTests
     {
         await TestEnvironment.ResetAsync();
 
-        var ctx = KsqlContextBuilder.Create()
-            .UseSchemaRegistry("http://localhost:8081")
-            .BuildContext<DummyContext>();
+        var options = new KafkaContextOptions
+        {
+            BootstrapServers = "localhost:9093",
+            SchemaRegistryUrl = "http://localhost:8081"
+        };
+
+        await using var ctx = new DummyContext(options);
 
         var headers = new Dictionary<string, string> { ["is_dummy"] = "true" };
 

--- a/physicalTests/OssSamples/DummyFlagSchemaRecognitionTests.cs
+++ b/physicalTests/OssSamples/DummyFlagSchemaRecognitionTests.cs
@@ -1,5 +1,6 @@
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq.Core.Context;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -48,6 +49,8 @@ public class DummyFlagSchemaRecognitionTests
 
     public class DummyContext : KsqlContext
     {
+        public DummyContext() : base() { }
+        public DummyContext(KafkaContextOptions options) : base(options) { }
         protected override void OnModelCreating(IModelBuilder modelBuilder)
         {
             modelBuilder.Entity<OrderValue>().WithTopic("orders");
@@ -60,9 +63,13 @@ public class DummyFlagSchemaRecognitionTests
 
     private async Task ProduceDummyRecordsAsync()
     {
-        var ctx = KsqlContextBuilder.Create()
-            .UseSchemaRegistry("http://localhost:8081")
-            .BuildContext<DummyContext>();
+        var options = new KafkaContextOptions
+        {
+            BootstrapServers = "localhost:9093",
+            SchemaRegistryUrl = "http://localhost:8081"
+        };
+
+        await using var ctx = new DummyContext(options);
 
         var headers = new Dictionary<string, string> { ["is_dummy"] = "true" };
 

--- a/physicalTests/TestEnvironment.cs
+++ b/physicalTests/TestEnvironment.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using Microsoft.Extensions.Logging;
 
 using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq.Core.Context;
 using System.Threading.Tasks;
 
 namespace Kafka.Ksql.Linq.Tests.Integration;
@@ -36,13 +37,19 @@ internal static class TestEnvironment
 
     internal static KsqlContext CreateContext()
     {
-        return KsqlContextBuilder.Create()
-            .UseSchemaRegistry(SchemaRegistryUrl)
-            .BuildContext<AdminContext>();
+        var options = new KafkaContextOptions
+        {
+            BootstrapServers = KafkaBootstrapServers,
+            SchemaRegistryUrl = SchemaRegistryUrl
+        };
+
+        return new AdminContext(options);
     }
 
     internal class AdminContext : KsqlContext
     {
+        public AdminContext() : base() { }
+        public AdminContext(KafkaContextOptions options) : base(options) { }
         protected override bool SkipSchemaRegistration => true;
     }
 

--- a/src/Core/Context/KafkaContextOptions.cs
+++ b/src/Core/Context/KafkaContextOptions.cs
@@ -5,6 +5,16 @@ namespace Kafka.Ksql.Linq.Core.Context;
 
 public class KafkaContextOptions
 {
+    /// <summary>
+    /// Kafka bootstrap servers
+    /// </summary>
+    public string BootstrapServers { get; set; } = "localhost:9092";
+
+    /// <summary>
+    /// Schema Registry base URL
+    /// </summary>
+    public string SchemaRegistryUrl { get; set; } = "http://localhost:8081";
+
     public ValidationMode ValidationMode { get; set; } = ValidationMode.Strict;
 
     public IConfiguration? Configuration { get; set; }


### PR DESCRIPTION
## Summary
- add BootstrapServers and SchemaRegistryUrl to `KafkaContextOptions`
- update physical tests to instantiate context subclasses using `KafkaContextOptions`
- add constructors to test contexts for options support
- log progress

## Testing
- `dotnet test physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj --filter Category=Integration` *(tests skipped: Broker transport failure)*

------
https://chatgpt.com/codex/tasks/task_e_687cea8014988327afa84f49f1a30c84