### PR TITLE
Use existing Kafka settings for ksqlDB URL

### DIFF
--- a/docs/changes/20250731_progress.md
+++ b/docs/changes/20250731_progress.md
@@ -89,3 +89,17 @@
 - SendEntityAsync 変更に追従して物理テストを修正
 - 単体・統合テストを実行しビルドエラーを解消
 
+## 2025-07-20 23:56 JST [assistant]
+- KSQL DB URL の構成キー `KsqlDb:Url` をドキュメント化し単体テストを追加
+
+## 2025-07-20 15:03 JST [assistant]
+- ksqlDB URL を SchemaRegistry または BootstrapServers から推定するよう修正
+- `KsqlDb:Url` 設定とドキュメントを撤回
+
+## 2025-07-20 15:26 JST [assistant]
+- Move CommonSection to Core and update extensions to read ksqlDB URL from CommonSection
+
+
+## 2025-07-21 00:32 JST [assistant]
+- derive ksqlDB port from configuration instead of hardcoding 8088
+- adjusted unit tests for dynamic port lookup

--- a/docs/docs_configuration_reference.md
+++ b/docs/docs_configuration_reference.md
@@ -255,7 +255,6 @@ Consumer の設定は `ConsumerSection` クラスにそれぞれマッピング�
 | `DecimalPrecision` | decimal型のprecisionを一括設定 |
 | `DecimalScale` | decimal型のscaleを一括設定 |
 
-
 ### 🧩 DSL記述とappsettingsの対応関係
 
 | Kafka設定項目             | DSLでの指定                          | appsettings.jsonキー                         | 補足説明 |

--- a/physicalTests/TestEnvironment.cs
+++ b/physicalTests/TestEnvironment.cs
@@ -15,7 +15,6 @@ namespace Kafka.Ksql.Linq.Tests.Integration;
 
 internal static class TestEnvironment
 {
-    private const string KsqlDbUrl = "http://localhost:8088";
     private const string SchemaRegistryUrl = "http://localhost:8081";
     private const string KafkaBootstrapServers = "localhost:9093";
     private const string DlqTopic = "dead.letter.queue";

--- a/src/Application/KsqlDbExecutionExtensions.cs
+++ b/src/Application/KsqlDbExecutionExtensions.cs
@@ -3,6 +3,9 @@ using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Kafka.Ksql.Linq.Core.Context;
+using Kafka.Ksql.Linq.Core.Configuration;
+using Microsoft.Extensions.Configuration;
 
 namespace Kafka.Ksql.Linq.Application;
 
@@ -12,14 +15,53 @@ public static class KsqlDbExecutionExtensions
 {
     private static readonly Uri DefaultKsqlDbUrl = new("http://localhost:8088");
 
-    private static HttpClient CreateClient()
+    private static CommonSection GetCommonSection(KsqlContext context)
     {
-        return new HttpClient { BaseAddress = DefaultKsqlDbUrl };
+        var options = context.GetOptions();
+        var config = options.Configuration;
+
+        var section = new CommonSection { BootstrapServers = options.BootstrapServers };
+        config?.GetSection("KsqlDsl:Common").Bind(section);
+        return section;
+    }
+
+    private static Uri GetKsqlDbUrl(KsqlContext context)
+    {
+        var config = context.GetOptions().Configuration;
+
+        var schemaUrl = config?["KsqlDsl:SchemaRegistry:Url"];
+        if (!string.IsNullOrWhiteSpace(schemaUrl) &&
+            Uri.TryCreate(schemaUrl, UriKind.Absolute, out var uri))
+        {
+            var port = uri.IsDefaultPort ? DefaultKsqlDbUrl.Port : uri.Port;
+            return new Uri($"{uri.Scheme}://{uri.Host}:{port}");
+        }
+
+        var bootstrap = GetCommonSection(context).BootstrapServers;
+        if (!string.IsNullOrWhiteSpace(bootstrap))
+        {
+            var first = bootstrap.Split(',')[0];
+            var hostParts = first.Split(':');
+            var host = hostParts[0];
+            int port = DefaultKsqlDbUrl.Port;
+            if (hostParts.Length > 1 && int.TryParse(hostParts[1], out var parsed))
+            {
+                port = parsed;
+            }
+            return new Uri($"http://{host}:{port}");
+        }
+
+        return DefaultKsqlDbUrl;
+    }
+
+    private static HttpClient CreateClient(KsqlContext context)
+    {
+        return new HttpClient { BaseAddress = GetKsqlDbUrl(context) };
     }
 
     public static async Task<KsqlDbResponse> ExecuteStatementAsync(this KsqlContext context, string statement)
     {
-        using var client = CreateClient();
+        using var client = CreateClient(context);
         var payload = new { ksql = statement, streamsProperties = new { } };
         var json = JsonSerializer.Serialize(payload);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");

--- a/src/Configuration/KsqlDslOptions.cs
+++ b/src/Configuration/KsqlDslOptions.cs
@@ -1,6 +1,7 @@
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Attributes;
 using Kafka.Ksql.Linq.Messaging.Configuration;
+using Kafka.Ksql.Linq.Core.Configuration;
 using System.Collections.Generic;
 
 namespace Kafka.Ksql.Linq.Configuration;

--- a/src/Core/Configuration/CommonSection.cs
+++ b/src/Core/Configuration/CommonSection.cs
@@ -1,7 +1,7 @@
 ﻿using Confluent.Kafka;
 using System.Collections.Generic;
 
-namespace Kafka.Ksql.Linq.Messaging.Configuration;
+namespace Kafka.Ksql.Linq.Core.Configuration;
 public class CommonSection
 {
     /// <summary>

--- a/src/Core/Context/KafkaContextCore.cs
+++ b/src/Core/Context/KafkaContextCore.cs
@@ -31,6 +31,8 @@ public abstract class KafkaContextCore : IKsqlContext
         Options = options ?? throw new ArgumentNullException(nameof(options));
         InitializeEntityModels();
     }
+
+    public KafkaContextOptions GetOptions() => Options;
     protected virtual void OnModelCreating(IModelBuilder modelBuilder) { }
     // ✅ IKsqlContext実装: エンティティセット取得（純粋関数）
     public IEntitySet<T> Set<T>() where T : class

--- a/src/Messaging/Consumers/KafkaConsumerManager.cs
+++ b/src/Messaging/Consumers/KafkaConsumerManager.cs
@@ -5,6 +5,7 @@ using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Extensions;
 using Kafka.Ksql.Linq.Messaging.Abstractions;
 using Kafka.Ksql.Linq.Messaging.Configuration;
+using Kafka.Ksql.Linq.Core.Configuration;
 using Kafka.Ksql.Linq.Messaging.Consumers.Core;
 using Chr.Avro.Confluent;
 using Confluent.Kafka.SyncOverAsync;

--- a/src/Messaging/Producers/KafkaProducerManager.cs
+++ b/src/Messaging/Producers/KafkaProducerManager.cs
@@ -4,6 +4,7 @@ using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Extensions;
 using Kafka.Ksql.Linq.Messaging.Abstractions;
 using Kafka.Ksql.Linq.Messaging.Configuration;
+using Kafka.Ksql.Linq.Core.Configuration;
 using Kafka.Ksql.Linq.Messaging.Producers.Core;
 using Chr.Avro.Confluent;
 using Confluent.Kafka.SyncOverAsync;

--- a/tests/Application/KsqlDbExecutionExtensionsTests.cs
+++ b/tests/Application/KsqlDbExecutionExtensionsTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Reflection;
+using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq.Core.Context;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Application;
+
+public class KsqlDbExecutionExtensionsTests
+{
+    private class DummyContext : KsqlContext
+    {
+        public DummyContext(KafkaContextOptions opt) : base(opt) { }
+        protected override bool SkipSchemaRegistration => true;
+        protected override void OnModelCreating(Kafka.Ksql.Linq.Core.Abstractions.IModelBuilder modelBuilder) { }
+    }
+
+    [Fact]
+    public void CreateClient_UsesSchemaRegistryHost()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                { "KsqlDsl:SchemaRegistry:Url", "http://example.com:8085" }
+            })
+            .Build();
+
+        var options = new KafkaContextOptions { Configuration = config };
+        var ctx = new DummyContext(options);
+
+        var method = typeof(KsqlDbExecutionExtensions)
+            .GetMethod("CreateClient", BindingFlags.NonPublic | BindingFlags.Static)!;
+        using var client = (HttpClient)method.Invoke(null, new object[] { ctx })!;
+        Assert.Equal(new Uri("http://example.com:8085"), client.BaseAddress);
+    }
+
+    [Fact]
+    public void CreateClient_FallsBackToBootstrapServers()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                { "KsqlDsl:Common:BootstrapServers", "example.com:9092" }
+            })
+            .Build();
+
+        var options = new KafkaContextOptions { Configuration = config };
+        var ctx = new DummyContext(options);
+
+        var method = typeof(KsqlDbExecutionExtensions)
+            .GetMethod("CreateClient", BindingFlags.NonPublic | BindingFlags.Static)!;
+        using var client = (HttpClient)method.Invoke(null, new object[] { ctx })!;
+        Assert.Equal(new Uri("http://example.com:9092"), client.BaseAddress);
+    }
+}

--- a/tests/Configuration/MessagingConfigurationTests.cs
+++ b/tests/Configuration/MessagingConfigurationTests.cs
@@ -1,4 +1,5 @@
 using Kafka.Ksql.Linq.Messaging.Configuration;
+using Kafka.Ksql.Linq.Core.Configuration;
 using Xunit;
 
 namespace Kafka.Ksql.Linq.Tests.Configuration;

--- a/tests/Infrastructure/Consumer/KafkaConsumerManagerTests.cs
+++ b/tests/Infrastructure/Consumer/KafkaConsumerManagerTests.cs
@@ -14,6 +14,7 @@ using Kafka.Ksql.Linq.Messaging.Consumers;
 using Kafka.Ksql.Linq.Messaging.Producers;
 using Kafka.Ksql.Linq.Core.Dlq;
 using Kafka.Ksql.Linq.Messaging.Configuration;
+using Kafka.Ksql.Linq.Core.Configuration;
 using Microsoft.Extensions.Options;
 using System.Reflection;
 using Microsoft.Extensions.Logging;

--- a/tests/Infrastructure/KafkaAdminServiceTests.cs
+++ b/tests/Infrastructure/KafkaAdminServiceTests.cs
@@ -6,6 +6,7 @@ using Confluent.Kafka;
 using Confluent.Kafka.Admin;
 using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.Messaging.Configuration;
+using Kafka.Ksql.Linq.Core.Configuration;
 using Kafka.Ksql.Linq.Infrastructure.Admin;
 using Xunit;
 using static Kafka.Ksql.Linq.Tests.PrivateAccessor;

--- a/tests/Messaging/KafkaConsumerManagerTests.cs
+++ b/tests/Messaging/KafkaConsumerManagerTests.cs
@@ -8,6 +8,7 @@ using Confluent.SchemaRegistry;
 using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.Configuration.Abstractions;
 using Kafka.Ksql.Linq.Messaging.Configuration;
+using Kafka.Ksql.Linq.Core.Configuration;
 using Kafka.Ksql.Linq.Messaging.Producers;
 using Kafka.Ksql.Linq.Messaging.Consumers;
 using Kafka.Ksql.Linq.Core.Dlq;

--- a/tests/Messaging/KafkaProducerManagerDisposeTests.cs
+++ b/tests/Messaging/KafkaProducerManagerDisposeTests.cs
@@ -2,6 +2,7 @@ using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Messaging.Abstractions;
 using Kafka.Ksql.Linq.Messaging.Configuration;
+using Kafka.Ksql.Linq.Core.Configuration;
 using Kafka.Ksql.Linq.Messaging.Producers;
 using Kafka.Ksql.Linq.Messaging.Producers.Core;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/tests/Messaging/KafkaProducerManagerExtraTests.cs
+++ b/tests/Messaging/KafkaProducerManagerExtraTests.cs
@@ -2,6 +2,7 @@ using Confluent.SchemaRegistry;
 using Confluent.Kafka;
 using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.Messaging.Configuration;
+using Kafka.Ksql.Linq.Core.Configuration;
 using Kafka.Ksql.Linq.Messaging.Producers;
 using System.Collections.Generic;
 using System.Collections.Concurrent;

--- a/tests/Messaging/KafkaProducerManagerTests.cs
+++ b/tests/Messaging/KafkaProducerManagerTests.cs
@@ -7,6 +7,7 @@ using Confluent.Kafka;
 using Confluent.SchemaRegistry;
 using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.Messaging.Configuration;
+using Kafka.Ksql.Linq.Core.Configuration;
 using Kafka.Ksql.Linq.Messaging.Producers;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;


### PR DESCRIPTION
## Summary
- derive ksqlDB URL host and port from Schema Registry or bootstrap servers
- update unit tests to check port from config
- log progress of removing hard-coded port

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj -v n`


------
https://chatgpt.com/codex/tasks/task_e_687cfde7e4708327bc0dcb22a7ad633e