### PR TITLE
Refactor schema registry section

### DIFF
--- a/docs/changes/20250731_progress.md
+++ b/docs/changes/20250731_progress.md
@@ -115,3 +115,5 @@
 - Replace hard-coded Schema Registry URL with configuration lookup
 ## 2025-07-21 03:33 JST [assistant]
 - Moved SchemaRegistrySection to Core namespace and updated docs
+## 2025-07-21 04:08 JST [assistant]
+- Updated caching tests to provide SchemaRegistry URL per docs

--- a/docs/changes/20250731_progress.md
+++ b/docs/changes/20250731_progress.md
@@ -110,3 +110,8 @@
 ## 2025-07-21 01:35 JST [assistant]
 - ksqlDB client helpers now read from _dslOptions instead of KafkaContextOptions
 - Updated unit tests for new configuration source
+
+## 2025-07-21 03:20 JST [assistant]
+- Replace hard-coded Schema Registry URL with configuration lookup
+## 2025-07-21 03:33 JST [assistant]
+- Moved SchemaRegistrySection to Core namespace and updated docs

--- a/docs/namespaces/core_namespace_doc.md
+++ b/docs/namespaces/core_namespace_doc.md
@@ -24,6 +24,7 @@ Kafka.Ksql.Linq.Coreは、Apache KafkaとKsqlDBを使ったストリーミング
 **責務**: Core層設定管理
 - `CoreSettings`: Kafka接続・検証モード設定
 - `CoreSettingsProvider`: 設定変更の監視・通知
+- `SchemaRegistrySection`: Schema Registry 接続設定
 
 ### `Kafka.Ksql.Linq.Core.Context`
 **責務**: コンテキスト基底実装

--- a/docs/namespaces/messaging_namespace_doc.md
+++ b/docs/namespaces/messaging_namespace_doc.md
@@ -15,7 +15,7 @@ Kafka メッセージング機能の型安全な抽象化層を提供する name
 - **`CommonSection`**: Kafka ブローカー共通設定（接続、セキュリティ）
 - **`ProducerSection`**: Producer 固有設定（確認応答、圧縮、冪等性）
 - **`ConsumerSection`**: Consumer 固有設定（グループ、オフセット、フェッチ）
-- **`SchemaRegistrySection`**: Schema Registry 接続設定
+- **`SchemaRegistrySection`** (Core namespace): Schema Registry 接続設定
 - **`TopicSection`**: トピック別設定（Producer/Consumer 両方を含む）
 
 **設計意図**: 設定の階層化、運用時の柔軟性確保

--- a/src/Configuration/KsqlDslOptions.cs
+++ b/src/Configuration/KsqlDslOptions.cs
@@ -1,7 +1,7 @@
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Attributes;
-using Kafka.Ksql.Linq.Messaging.Configuration;
 using Kafka.Ksql.Linq.Core.Configuration;
+using Kafka.Ksql.Linq.Messaging.Configuration;
 using System.Collections.Generic;
 
 namespace Kafka.Ksql.Linq.Configuration;

--- a/src/Core/Configuration/SchemaRegistrySection.cs
+++ b/src/Core/Configuration/SchemaRegistrySection.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace Kafka.Ksql.Linq.Messaging.Configuration;
+namespace Kafka.Ksql.Linq.Core.Configuration;
 
 /// <summary>
 /// Schema Registry configuration (follows Confluent.Kafka specifications)
@@ -10,7 +10,7 @@ public class SchemaRegistrySection
     /// <summary>
     /// A comma-separated list of URLs for schema registry instances
     /// </summary>
-    public string Url { get; init; } = "http://localhost:8081";
+    public string Url { get; init; } = string.Empty;
 
     /// <summary>
     /// Maximum number of schemas to cache locally

--- a/src/Core/Context/KafkaContextOptions.cs
+++ b/src/Core/Context/KafkaContextOptions.cs
@@ -11,9 +11,9 @@ public class KafkaContextOptions
     public string BootstrapServers { get; set; } = "localhost:9092";
 
     /// <summary>
-    /// Schema Registry base URL
+    /// Schema Registry base URL (see docs_configuration_reference.md)
     /// </summary>
-    public string SchemaRegistryUrl { get; set; } = "http://localhost:8081";
+    public string SchemaRegistryUrl { get; set; } = string.Empty;
 
     public ValidationMode ValidationMode { get; set; } = ValidationMode.Strict;
 

--- a/src/KsqlContext.cs
+++ b/src/KsqlContext.cs
@@ -199,11 +199,12 @@ public abstract class KsqlContext : KafkaContextCore
     /// </summary>
     private ConfluentSchemaRegistry.ISchemaRegistryClient CreateSchemaRegistryClient()
     {
+        var options = _dslOptions.SchemaRegistry;
         var config = new ConfluentSchemaRegistry.SchemaRegistryConfig
         {
-            Url = "http://localhost:8081", // デフォルト値、実際は設定から取得
-            MaxCachedSchemas = 1000,
-            RequestTimeoutMs = 30000
+            Url = options.Url,
+            MaxCachedSchemas = options.MaxCachedSchemas,
+            RequestTimeoutMs = options.RequestTimeoutMs
         };
 
         return new ConfluentSchemaRegistry.CachedSchemaRegistryClient(config);

--- a/tests/Messaging/KafkaConsumerManagerTests.cs
+++ b/tests/Messaging/KafkaConsumerManagerTests.cs
@@ -101,7 +101,11 @@ public class KafkaConsumerManagerTests
     [Fact]
     public void DeserializerCaching_WorksPerType()
     {
-        var manager = new KafkaConsumerManager(Options.Create(new KsqlDslOptions()), new NullLoggerFactory());
+        var optionsForCache = new KsqlDslOptions
+        {
+            SchemaRegistry = new SchemaRegistrySection { Url = "http://example" }
+        };
+        var manager = new KafkaConsumerManager(Options.Create(optionsForCache), new NullLoggerFactory());
         var d1 = InvokePrivate<IDeserializer<object>>(manager, "CreateKeyDeserializer", new[] { typeof(Type) }, null, typeof(int));
         var d2 = InvokePrivate<IDeserializer<object>>(manager, "CreateKeyDeserializer", new[] { typeof(Type) }, null, typeof(int));
         var cache = (ConcurrentDictionary<Type, IDeserializer<object>>)typeof(KafkaConsumerManager)

--- a/tests/Messaging/KafkaProducerManagerExtraTests.cs
+++ b/tests/Messaging/KafkaProducerManagerExtraTests.cs
@@ -109,7 +109,11 @@ public class KafkaProducerManagerExtraTests
     [Fact]
     public void SerializerCaching_WorksPerType()
     {
-        var manager = new KafkaProducerManager(Options.Create(new KsqlDslOptions()), null);
+        var options = new KsqlDslOptions
+        {
+            SchemaRegistry = new SchemaRegistrySection { Url = "http://example" }
+        };
+        var manager = new KafkaProducerManager(Options.Create(options), null);
         var s1 = InvokePrivate<ISerializer<object>>(manager, "CreateKeySerializer", new[] { typeof(Type) }, null, typeof(int));
         var s2 = InvokePrivate<ISerializer<object>>(manager, "CreateKeySerializer", new[] { typeof(Type) }, null, typeof(int));
         var cache = (ConcurrentDictionary<Type, ISerializer<object>>)typeof(KafkaProducerManager)


### PR DESCRIPTION
## Summary
- move `SchemaRegistrySection` to Core namespace
- document the new location in namespace docs
- log today's refactoring

## Testing
- `dotnet test --list-tests` *(fails: Broker transport failure)*

------
https://chatgpt.com/codex/tasks/task_e_687d3295100c8327b7e1ee1248ace534