### PR TITLE
Update bootstrap server defaults

### DIFF
--- a/docs/changes/20250731_progress.md
+++ b/docs/changes/20250731_progress.md
@@ -117,3 +117,7 @@
 - Moved SchemaRegistrySection to Core namespace and updated docs
 ## 2025-07-21 04:08 JST [assistant]
 - Updated caching tests to provide SchemaRegistry URL per docs
+## 2025-07-20 20:43 JST [assistant]
+- KafkaContextOptions BootstrapServers now proxies CommonSection.BootstrapServers
+- Default KSQL DB URL derived from CommonSection BootstrapServers
+

--- a/src/Core/Context/KafkaContextOptions.cs
+++ b/src/Core/Context/KafkaContextOptions.cs
@@ -1,4 +1,5 @@
 using Kafka.Ksql.Linq.Configuration;
+using Kafka.Ksql.Linq.Core.Configuration;
 using Microsoft.Extensions.Configuration;
 
 namespace Kafka.Ksql.Linq.Core.Context;
@@ -6,9 +7,18 @@ namespace Kafka.Ksql.Linq.Core.Context;
 public class KafkaContextOptions
 {
     /// <summary>
+    /// Common Kafka settings (BootstrapServers, ClientId, etc.)
+    /// </summary>
+    public CommonSection Common { get; set; } = new();
+
+    /// <summary>
     /// Kafka bootstrap servers
     /// </summary>
-    public string BootstrapServers { get; set; } = "localhost:9092";
+    public string BootstrapServers
+    {
+        get => Common.BootstrapServers;
+        set => Common = new CommonSection { BootstrapServers = value };
+    }
 
     /// <summary>
     /// Schema Registry base URL (see docs_configuration_reference.md)


### PR DESCRIPTION
## Summary
- expose CommonSection in `KafkaContextOptions`
- compute ksqlDB URL from CommonSection bootstrap servers
- record progress log

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: Kafka connectivity)*

------
https://chatgpt.com/codex/tasks/task_e_687d52a82edc8327a186398cd49bcc6b