### PR TITLE
Fix default ksqlDB URL handling

### DIFF
--- a/docs/changes/20250731_progress.md
+++ b/docs/changes/20250731_progress.md
@@ -121,3 +121,5 @@
 - KafkaContextOptions BootstrapServers now proxies CommonSection.BootstrapServers
 - Default KSQL DB URL derived from CommonSection BootstrapServers
 
+## 2025-07-21 05:53 JST [assistant]
+- GetDefaultKsqlDbUrl now throws when KSQL DB URL cannot be resolved

--- a/src/KsqlContext.cs
+++ b/src/KsqlContext.cs
@@ -56,7 +56,8 @@ public abstract class KsqlContext : KafkaContextCore
             return new Uri($"http://{host}:{port}");
         }
 
-        return new Uri("http://localhost:8088");
+        throw new InvalidOperationException(
+            "FATAL: ksqlDB URL could not be determined. Configure BootstrapServers or SchemaRegistry Url.");
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- throw when GetDefaultKsqlDbUrl cannot derive URL
- log progress

## Testing
- `dotnet build Kafka.Ksql.Linq.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687d56b3e3cc8327a895fec7835bbf3c