### PR TITLE
Refactor KsqlContext ctor usage in tests

### DIFF
--- a/physicalTests/KsqlSyntax/DynamicKsqlGenerationTests.cs
+++ b/physicalTests/KsqlSyntax/DynamicKsqlGenerationTests.cs
@@ -334,7 +334,7 @@ public class DynamicKsqlGenerationTests
 
     public class DummyContext : KsqlContext
     {
-        public DummyContext() : base() { }
+        public DummyContext() : base(new KafkaContextOptions()) { }
         public DummyContext(KafkaContextOptions options) : base(options) { }
         protected override void OnModelCreating(IModelBuilder modelBuilder)
         {

--- a/physicalTests/OssSamples/DummyFlagMessageTests.cs
+++ b/physicalTests/OssSamples/DummyFlagMessageTests.cs
@@ -24,7 +24,7 @@ public class DummyFlagMessageTests
 
     public class DummyContext : KsqlContext
     {
-        public DummyContext() : base() { }
+        public DummyContext() : base(new KafkaContextOptions()) { }
         public DummyContext(KafkaContextOptions options) : base(options) { }
         protected override void OnModelCreating(IModelBuilder modelBuilder)
         {

--- a/physicalTests/OssSamples/DummyFlagSchemaRecognitionTests.cs
+++ b/physicalTests/OssSamples/DummyFlagSchemaRecognitionTests.cs
@@ -49,7 +49,7 @@ public class DummyFlagSchemaRecognitionTests
 
     public class DummyContext : KsqlContext
     {
-        public DummyContext() : base() { }
+        public DummyContext() : base(new KafkaContextOptions()) { }
         public DummyContext(KafkaContextOptions options) : base(options) { }
         protected override void OnModelCreating(IModelBuilder modelBuilder)
         {

--- a/physicalTests/OssSamples/SchemaNameCaseSensitivityTests.cs
+++ b/physicalTests/OssSamples/SchemaNameCaseSensitivityTests.cs
@@ -30,7 +30,7 @@ public class SchemaNameCaseSensitivityTests
 
     public class OrderContext : KsqlContext
     {
-        public OrderContext() : base() { }
+        public OrderContext() : base(new KafkaContextOptions()) { }
         public OrderContext(KafkaContextOptions options) : base(options) { }
         protected override void OnModelCreating(IModelBuilder modelBuilder)
         {
@@ -41,7 +41,7 @@ public class SchemaNameCaseSensitivityTests
     // Context for OrderWrongCase using default serialization
     public class WrongCaseContext : KsqlContext
     {
-        public WrongCaseContext() : base() { }
+        public WrongCaseContext() : base(new KafkaContextOptions()) { }
         public WrongCaseContext(KafkaContextOptions options) : base(options) { }
         protected override void OnModelCreating(IModelBuilder modelBuilder)
         {

--- a/physicalTests/TestEnvironment.cs
+++ b/physicalTests/TestEnvironment.cs
@@ -47,7 +47,7 @@ internal static class TestEnvironment
 
     internal class AdminContext : KsqlContext
     {
-        public AdminContext() : base() { }
+        public AdminContext() : base(new KafkaContextOptions()) { }
         public AdminContext(KafkaContextOptions options) : base(options) { }
         protected override bool SkipSchemaRegistration => false;
     }

--- a/tests/Application/EventSetWithServicesRocksDbTests.cs
+++ b/tests/Application/EventSetWithServicesRocksDbTests.cs
@@ -1,6 +1,7 @@
 using Kafka.Ksql.Linq.Application;
 using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Context;
 using Kafka.Ksql.Linq.Cache.Core;
 using Kafka.Ksql.Linq.Cache.Extensions;
 using Kafka.Ksql.Linq.Cache;
@@ -15,7 +16,7 @@ public class EventSetWithServicesRocksDbTests
 {
     private class TestContext : KsqlContext
     {
-        public TestContext() : base() { }
+        public TestContext() : base(new KafkaContextOptions()) { }
 
         protected override bool SkipSchemaRegistration => true;
 

--- a/tests/Application/EventSetWithServicesSendTests.cs
+++ b/tests/Application/EventSetWithServicesSendTests.cs
@@ -37,7 +37,7 @@ public class EventSetWithServicesSendTests
 
     private class TestContext : KsqlContext
     {
-        public TestContext() : base() { }
+        public TestContext() : base(new KafkaContextOptions()) { }
 
         protected override bool SkipSchemaRegistration => true;
 

--- a/tests/Application/EventSetWithServicesTests.cs
+++ b/tests/Application/EventSetWithServicesTests.cs
@@ -10,7 +10,7 @@ public class EventSetWithServicesTests
 {
     private class TestContext : KsqlContext
     {
-        public TestContext() : base() { }
+        public TestContext() : base(new KafkaContextOptions()) { }
 
         protected override bool SkipSchemaRegistration => true;
     }

--- a/tests/Application/KsqlContextAsyncTests.cs
+++ b/tests/Application/KsqlContextAsyncTests.cs
@@ -13,7 +13,7 @@ public class KsqlContextAsyncTests
 {
     private class TestContext : KsqlContext
     {
-        public TestContext() : base() { }
+        public TestContext() : base(new KafkaContextOptions()) { }
 
         protected override bool SkipSchemaRegistration => true;
     }

--- a/tests/Application/KsqlContextBindingEventTests.cs
+++ b/tests/Application/KsqlContextBindingEventTests.cs
@@ -1,6 +1,7 @@
 using Kafka.Ksql.Linq.Application;
 using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Context;
 using Kafka.Ksql.Linq.Cache.Core;
 using System;
 using System.Collections.Generic;
@@ -14,7 +15,7 @@ public class KsqlContextBindingEventTests
 {
     private class BindingContext : KsqlContext
     {
-        public BindingContext() : base() { }
+        public BindingContext() : base(new KafkaContextOptions()) { }
 
         protected override bool SkipSchemaRegistration => true;
 

--- a/tests/Application/KsqlContextBuilderTests.cs
+++ b/tests/Application/KsqlContextBuilderTests.cs
@@ -8,7 +8,7 @@ namespace Kafka.Ksql.Linq.Tests.Application;
 // Dummy context used for KsqlContextBuilder tests
 public class DummyContext : KsqlContext
 {
-    public DummyContext() : base() { }
+    public DummyContext() : base(new KafkaContextOptions()) { }
     public DummyContext(KafkaContextOptions options) : base(options) { }
 
     // Skip heavy initialization during tests

--- a/tests/Application/KsqlContextDlqSendTests.cs
+++ b/tests/Application/KsqlContextDlqSendTests.cs
@@ -6,6 +6,7 @@ using Kafka.Ksql.Linq.Core.Models;
 using Kafka.Ksql.Linq.Messaging.Producers;
 using Kafka.Ksql.Linq.Messaging.Producers.Core;
 using Kafka.Ksql.Linq.Core.Dlq;
+using Kafka.Ksql.Linq.Core.Context;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -38,7 +39,7 @@ public class KsqlContextDlqSendTests
 
     private class TestContext : KsqlContext
     {
-        public TestContext() : base() { }
+        public TestContext() : base(new KafkaContextOptions()) { }
 
         protected override bool SkipSchemaRegistration => true;
 

--- a/tests/Application/KsqlContextTests.cs
+++ b/tests/Application/KsqlContextTests.cs
@@ -15,7 +15,7 @@ public class KsqlContextTests
 {
     private class TestContext : KsqlContext
     {
-        public TestContext() : base() { }
+        public TestContext() : base(new KafkaContextOptions()) { }
         public TestContext(KafkaContextOptions opt) : base(opt) { }
 
         protected override bool SkipSchemaRegistration => true;

--- a/tests/Mapping/AddAsyncSampleFlowTests.cs
+++ b/tests/Mapping/AddAsyncSampleFlowTests.cs
@@ -4,6 +4,7 @@ using Kafka.Ksql.Linq.Mapping;
 using Kafka.Ksql.Linq.Messaging.Abstractions;
 using Kafka.Ksql.Linq.Messaging.Producers.Core;
 using Kafka.Ksql.Linq.Configuration;
+using Kafka.Ksql.Linq.Core.Context;
 using Kafka.Ksql.Linq.Entities.Samples.Models;
 using Kafka.Ksql.Linq.Query.Schema;
 using Kafka.Ksql.Linq.Core.Models;
@@ -43,7 +44,7 @@ public class AddAsyncSampleFlowTests
 
     private class TestContext : KsqlContext
     {
-        public TestContext() : base() { }
+        public TestContext() : base(new KafkaContextOptions()) { }
         protected override bool SkipSchemaRegistration => true;
         public void SetProducerManager(KafkaProducerManager manager)
         {

--- a/tests/Mapping/AutomaticQueryFlowTests.cs
+++ b/tests/Mapping/AutomaticQueryFlowTests.cs
@@ -44,7 +44,7 @@ public class AutomaticQueryFlowTests
 
     private class TestContext : KsqlContext
     {
-        public TestContext() : base() { }
+        public TestContext() : base(new KafkaContextOptions()) { }
         protected override bool SkipSchemaRegistration => true;
         public void SetProducer(object manager)
         {

--- a/tests/Mapping/FullAutoQueryFlowTests.cs
+++ b/tests/Mapping/FullAutoQueryFlowTests.cs
@@ -45,7 +45,7 @@ public class FullAutoQueryFlowTests
 
     private class TestContext : KsqlContext
     {
-        public TestContext() : base() { }
+        public TestContext() : base(new KafkaContextOptions()) { }
         protected override bool SkipSchemaRegistration => true;
         public void SetProducerManager(KafkaProducerManager manager)
         {

--- a/tests/Query/QueryAnalyzerTests.cs
+++ b/tests/Query/QueryAnalyzerTests.cs
@@ -4,6 +4,7 @@ using System.Linq.Expressions;
 using Kafka.Ksql.Linq.Query.Analysis;
 using Kafka.Ksql.Linq.Application;
 using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Context;
 using Kafka.Ksql.Linq.Core.Modeling;
 using Xunit;
 
@@ -72,7 +73,7 @@ public class QueryAnalyzerTests
 
     private class TestContext : KsqlContext
     {
-        public TestContext() : base() { }
+        public TestContext() : base(new KafkaContextOptions()) { }
         protected override bool SkipSchemaRegistration => true;
 
         protected override void OnModelCreating(IModelBuilder modelBuilder)


### PR DESCRIPTION
## Summary
- migrate tests to new KsqlContext constructors
- update integration test contexts accordingly

## Testing
- `dotnet build -c Release`
- `dotnet test -c Release` *(fails: Kafka connectivity timeout)*

------
https://chatgpt.com/codex/tasks/task_e_687dd79d50e88327a8910aafb64131fa