### PR TITLE
Change KsqlContext namespace

### DIFF
--- a/examples/api-showcase/Program.cs
+++ b/examples/api-showcase/Program.cs
@@ -1,4 +1,4 @@
-using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;

--- a/examples/basic-produce-consume/Program.cs
+++ b/examples/basic-produce-consume/Program.cs
@@ -1,4 +1,4 @@
-using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;

--- a/examples/configuration-mapping/Program.cs
+++ b/examples/configuration-mapping/Program.cs
@@ -1,4 +1,4 @@
-using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;

--- a/examples/configuration/Program.cs
+++ b/examples/configuration/Program.cs
@@ -1,4 +1,4 @@
-using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;

--- a/examples/daily-comparison/DailyComparisonLib/KafkaKsqlContext.cs
+++ b/examples/daily-comparison/DailyComparisonLib/KafkaKsqlContext.cs
@@ -1,4 +1,4 @@
-using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Context;
 using Kafka.Ksql.Linq.Core.Modeling;

--- a/examples/daily-comparison/DailyComparisonLib/MyKsqlContext.cs
+++ b/examples/daily-comparison/DailyComparisonLib/MyKsqlContext.cs
@@ -1,4 +1,4 @@
-using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Core.Context;
 using Microsoft.Extensions.Configuration;
 

--- a/examples/error-handling-dlq/Program.cs
+++ b/examples/error-handling-dlq/Program.cs
@@ -1,4 +1,4 @@
-using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;

--- a/examples/error-handling/Program.cs
+++ b/examples/error-handling/Program.cs
@@ -1,4 +1,4 @@
-using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;

--- a/examples/hello-world/Program.cs
+++ b/examples/hello-world/Program.cs
@@ -1,4 +1,4 @@
-using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;

--- a/examples/manual-commit/Program.cs
+++ b/examples/manual-commit/Program.cs
@@ -1,4 +1,4 @@
-using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;

--- a/examples/naruse/mapping_manager/Program.cs
+++ b/examples/naruse/mapping_manager/Program.cs
@@ -1,4 +1,4 @@
-using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Entities.Samples;
 using Kafka.Ksql.Linq.Entities.Samples.Models;

--- a/examples/sqlserver-vs-kafka/Program.cs
+++ b/examples/sqlserver-vs-kafka/Program.cs
@@ -1,4 +1,4 @@
-using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;

--- a/examples/window-finalization/Program.cs
+++ b/examples/window-finalization/Program.cs
@@ -1,4 +1,4 @@
-using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;

--- a/src/KsqlContext.cs
+++ b/src/KsqlContext.cs
@@ -23,8 +23,9 @@ using ConfluentSchemaRegistry = Confluent.SchemaRegistry;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Configuration;
 using Kafka.Ksql.Linq.Core.Configuration;
+using Kafka.Ksql.Linq.Application;
 
-namespace Kafka.Ksql.Linq.Application;
+namespace Kafka.Ksql.Linq;
 /// <summary>
 /// KsqlContext that integrates the Core layer.
 /// Design rationale: inherits core abstractions and integrates higher-level features.

--- a/src/Query/KeyValuePropertyProvider.cs
+++ b/src/Query/KeyValuePropertyProvider.cs
@@ -1,3 +1,4 @@
+using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Application;
 using Kafka.Ksql.Linq.Query.Abstractions;
 using Kafka.Ksql.Linq.Core.Models;

--- a/tests/Application/EventSetWithServicesRocksDbTests.cs
+++ b/tests/Application/EventSetWithServicesRocksDbTests.cs
@@ -1,3 +1,4 @@
+using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Application;
 using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.Core.Abstractions;

--- a/tests/Application/EventSetWithServicesSendTests.cs
+++ b/tests/Application/EventSetWithServicesSendTests.cs
@@ -1,10 +1,11 @@
 using Kafka.Ksql.Linq;
+using Kafka.Ksql.Linq.Application;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Context;
 using Kafka.Ksql.Linq.Messaging.Abstractions;
 using Kafka.Ksql.Linq.Messaging.Producers.Core;
 using Kafka.Ksql.Linq.Configuration;
-using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System;

--- a/tests/Application/EventSetWithServicesTests.cs
+++ b/tests/Application/EventSetWithServicesTests.cs
@@ -1,7 +1,8 @@
 using Kafka.Ksql.Linq;
+using Kafka.Ksql.Linq.Application;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Context;
-using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq;
 using Xunit;
 
 namespace Kafka.Ksql.Linq.Tests.Application;

--- a/tests/Application/KsqlContextAsyncTests.cs
+++ b/tests/Application/KsqlContextAsyncTests.cs
@@ -1,7 +1,7 @@
 using Kafka.Ksql.Linq;
+using Kafka.Ksql.Linq.Application;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Context;
-using Kafka.Ksql.Linq.Application;
 using System;
 using System.Reflection;
 using System.Threading.Tasks;

--- a/tests/Application/KsqlContextBindingEventTests.cs
+++ b/tests/Application/KsqlContextBindingEventTests.cs
@@ -1,4 +1,4 @@
-using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Context;

--- a/tests/Application/KsqlContextBuilderTests.cs
+++ b/tests/Application/KsqlContextBuilderTests.cs
@@ -1,3 +1,4 @@
+using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Application;
 using Kafka.Ksql.Linq.Core.Context;
 using Microsoft.Extensions.Configuration;

--- a/tests/Application/KsqlContextDlqSendTests.cs
+++ b/tests/Application/KsqlContextDlqSendTests.cs
@@ -1,4 +1,4 @@
-using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Messaging.Abstractions;

--- a/tests/Application/KsqlContextOptionsExtensionsTests.cs
+++ b/tests/Application/KsqlContextOptionsExtensionsTests.cs
@@ -1,3 +1,4 @@
+using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Application;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;

--- a/tests/Application/KsqlContextOptionsTests.cs
+++ b/tests/Application/KsqlContextOptionsTests.cs
@@ -1,4 +1,5 @@
 using System;
+using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Application;
 using Confluent.SchemaRegistry;
 using Xunit;

--- a/tests/Application/KsqlContextTests.cs
+++ b/tests/Application/KsqlContextTests.cs
@@ -4,7 +4,6 @@ using Kafka.Ksql.Linq.Core.Context;
 using Kafka.Ksql.Linq.Messaging.Consumers;
 using Kafka.Ksql.Linq.Messaging.Producers;
 using Kafka.Ksql.Linq.Core.Dlq;
-using Kafka.Ksql.Linq.Application;
 using Kafka.Ksql.Linq.Cache.Core;
 using System;
 using Xunit;

--- a/tests/Application/KsqlDbExecutionExtensionsTests.cs
+++ b/tests/Application/KsqlDbExecutionExtensionsTests.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Reflection;
-using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Core.Context;
 using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.Messaging.Configuration;

--- a/tests/Mapping/AddAsyncSampleFlowTests.cs
+++ b/tests/Mapping/AddAsyncSampleFlowTests.cs
@@ -1,4 +1,4 @@
-using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Mapping;
 using Kafka.Ksql.Linq.Messaging.Abstractions;

--- a/tests/Mapping/AutomaticQueryFlowTests.cs
+++ b/tests/Mapping/AutomaticQueryFlowTests.cs
@@ -1,4 +1,4 @@
-using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Context;
 using Kafka.Ksql.Linq.Core.Modeling;

--- a/tests/Mapping/FullAutoQueryFlowTests.cs
+++ b/tests/Mapping/FullAutoQueryFlowTests.cs
@@ -1,3 +1,4 @@
+using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Application;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Context;

--- a/tests/Query/QueryAnalyzerTests.cs
+++ b/tests/Query/QueryAnalyzerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 using Kafka.Ksql.Linq.Query.Analysis;
+using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Application;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Context;


### PR DESCRIPTION
## Summary
- change `KsqlContext` namespace to `Kafka.Ksql.Linq`
- update usages across source, tests and examples
- ensure extension methods still referenced by adding `Kafka.Ksql.Linq.Application` where needed

## Testing
- `dotnet build tests/Kafka.Ksql.Linq.Tests.csproj --no-restore`
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --no-build --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_687de2fbf3388327ab097f26463a2f1a