### PR TITLE
Fix AddAsync schema exception

### DIFF
--- a/docs/changes/20250721_progress.md
+++ b/docs/changes/20250721_progress.md
@@ -14,3 +14,7 @@
 ## 2025-07-21 17:00 JST [codex]
 - updated integration test contexts to use KsqlDslOptions after KafkaContextCore removal
 
+
+## 2025-07-21 23:13 JST [assistant]
+- updated AddAsync to rethrow SchemaRegistryException for case mismatch tests
+- executed `dotnet test`; integration tests failed due to missing Kafka

--- a/src/KsqlContext.cs
+++ b/src/KsqlContext.cs
@@ -563,6 +563,10 @@ internal class EventSetWithServices<T> : IEntitySet<T> where T : class
 
             await producerManager.SendAsync(entity, headers, cancellationToken);
         }
+        catch (ConfluentSchemaRegistry.SchemaRegistryException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             throw new InvalidOperationException($"Failed to send entity {typeof(T).Name} to Kafka", ex);


### PR DESCRIPTION
## Summary
- ensure AddAsync passes through SchemaRegistryException so integration tests catch it
- log progress for July 21

## Testing
- `dotnet test Kafka.Ksql.Linq.sln --verbosity minimal` *(fails: KsqlContext initialization failed)*

------
https://chatgpt.com/codex/tasks/task_e_687e49d8ffe0832791f781322efb055a