### PR TITLE
Add composite key test via Fluent API

### DIFF
--- a/docs/changes/20250721_progress.md
+++ b/docs/changes/20250721_progress.md
@@ -18,3 +18,10 @@
 ## 2025-07-21 23:13 JST [assistant]
 - updated AddAsync to rethrow SchemaRegistryException for case mismatch tests
 - executed `dotnet test`; integration tests failed due to missing Kafka
+## 2025-07-21 15:13 JST [shion]
+- 複数PKのPOCO送受信テストを追加 (CompositeKeyPocoTests)
+- TestSchemaとTestEnvironmentを更新しORDERS_MULTI_PKテーブルを管理
+## 2025-07-22 00:48 JST [assistant]
+- addressed feedback: composite key test uses Fluent API for PK setup; updated docs
+- executed `dotnet test -v m`; Kafka connectivity test failed
+

--- a/docs/changes/20250722_progress.md
+++ b/docs/changes/20250722_progress.md
@@ -15,3 +15,6 @@
 ## 2025-07-22 23:20 JST [codex]
 - MappingManager 正常系にキー未登録時のケースをviewpoints.mdへ追加。
 
+## 2025-07-22 01:09 JST [assistant]
+- remove raw DROP statements; use AdminContext helpers for teardown
+- added DropTableAsync/DropStreamAsync to AdminContext

--- a/physicalTests/OssSamples/CompositeKeyPocoTests.cs
+++ b/physicalTests/OssSamples/CompositeKeyPocoTests.cs
@@ -1,0 +1,59 @@
+using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Configuration;
+using Kafka.Ksql.Linq.Core.Configuration;
+using Kafka.Ksql.Linq.Entities.Samples.Models;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Integration;
+
+public class CompositeKeyPocoTests
+{
+    public class OrderContext : KsqlContext
+    {
+        public OrderContext() : base(new KsqlDslOptions()) { }
+        public OrderContext(KsqlDslOptions options) : base(options) { }
+        protected override void OnModelCreating(IModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Order>()
+                .WithTopic("orders_multi_pk")
+                .HasKey(o => new { o.OrderId, o.UserId });
+        }
+    }
+
+    [KsqlDbFact]
+    [Trait("Category", "Integration")]
+    public async Task SendAndReceive_CompositeKeyPoco()
+    {
+        await TestEnvironment.ResetAsync();
+
+        var options = new KsqlDslOptions
+        {
+            Common = new CommonSection { BootstrapServers = "localhost:9092" },
+            SchemaRegistry = new SchemaRegistrySection { Url = "http://localhost:8088" }
+        };
+
+        await using var ctx = new OrderContext(options);
+
+        await ctx.Set<Order>().AddAsync(new Order
+        {
+            OrderId = 1,
+            UserId = 2,
+            ProductId = 3,
+            Quantity = 4
+        });
+
+        var list = await ctx.Set<Order>().ToListAsync();
+        Assert.Single(list);
+
+        var consumed = new List<Order>();
+        await ctx.Set<Order>().ForEachAsync(o => { consumed.Add(o); return Task.CompletedTask; }, TimeSpan.FromSeconds(1));
+        Assert.Single(consumed);
+
+        await ctx.DisposeAsync();
+    }
+}

--- a/physicalTests/TestSchema.cs
+++ b/physicalTests/TestSchema.cs
@@ -39,7 +39,19 @@ internal static class TestSchema
         {
             ("CustomerId", "INT"),
             ("Amount", "DOUBLE")
+        },
+        ["orders_multi_pk"] = new[]
+        {
+            ("OrderId", "INT"),
+            ("UserId", "INT"),
+            ("ProductId", "INT"),
+            ("Quantity", "INT")
         }
+    };
+
+    public static readonly Dictionary<string, string[]> CompositePrimaryKeys = new()
+    {
+        ["orders_multi_pk"] = new[] { "OrderId", "UserId" }
     };
 
     public static IEnumerable<string> AllTableNames => Tables.Keys.Select(k => k.ToUpperInvariant());
@@ -53,12 +65,22 @@ internal static class TestSchema
     {
         foreach (var kvp in Tables)
         {
-            var cols = kvp.Value.Select((c, i) =>
-                i == 0
-                    ? $"{c.Name.ToUpperInvariant()} {c.Type} PRIMARY KEY"
-                    : $"{c.Name.ToUpperInvariant()} {c.Type}");
-            var colList = string.Join(", ", cols);
-            yield return $"CREATE TABLE IF NOT EXISTS {kvp.Key.ToUpperInvariant()} ({colList}) WITH (KAFKA_TOPIC='{kvp.Key}', VALUE_FORMAT='AVRO', KEY_FORMAT='AVRO', PARTITIONS=1);";
+            if (CompositePrimaryKeys.TryGetValue(kvp.Key, out var keys))
+            {
+                var cols = kvp.Value.Select(c => $"{c.Name.ToUpperInvariant()} {c.Type}");
+                var pk = $"PRIMARY KEY ({string.Join(", ", keys.Select(k => k.ToUpperInvariant()))})";
+                var colList = string.Join(", ", cols) + ", " + pk;
+                yield return $"CREATE TABLE IF NOT EXISTS {kvp.Key.ToUpperInvariant()} ({colList}) WITH (KAFKA_TOPIC='{kvp.Key}', VALUE_FORMAT='AVRO', KEY_FORMAT='AVRO', PARTITIONS=1);";
+            }
+            else
+            {
+                var cols = kvp.Value.Select((c, i) =>
+                    i == 0
+                        ? $"{c.Name.ToUpperInvariant()} {c.Type} PRIMARY KEY"
+                        : $"{c.Name.ToUpperInvariant()} {c.Type}");
+                var colList = string.Join(", ", cols);
+                yield return $"CREATE TABLE IF NOT EXISTS {kvp.Key.ToUpperInvariant()} ({colList}) WITH (KAFKA_TOPIC='{kvp.Key}', VALUE_FORMAT='AVRO', KEY_FORMAT='AVRO', PARTITIONS=1);";
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- add OrderContext fluent PK mapping for composite key
- create CompositeKeyPocoTests verifying send/receive
- extend TestSchema to create orders_multi_pk table with composite PK
- tear down orders_multi_pk table after tests using AdminContext helpers
- update progress log

## Testing
- `dotnet build Kafka.Ksql.Linq.sln -c Release -v q`
- `dotnet test physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj -c Release --no-build` *(fails: KafkaConnectivityTests.ProducerConsumer_RoundTrip)*

------
https://chatgpt.com/codex/tasks/task_e_687e57cccf088327a7bdeeb10b0b9d60