### PR TITLE
Add Kafka down integration tests

### DIFF
--- a/docs/changes/20250722_progress.md
+++ b/docs/changes/20250722_progress.md
@@ -18,3 +18,6 @@
 ## 2025-07-22 01:09 JST [assistant]
 - remove raw DROP statements; use AdminContext helpers for teardown
 - added DropTableAsync/DropStreamAsync to AdminContext
+
+## 2025-07-22 13:30 JST [shion]
+- Kafka停止時の例外テストを追加

--- a/physicalTests/Connectivity/KafkaServiceDownTests.cs
+++ b/physicalTests/Connectivity/KafkaServiceDownTests.cs
@@ -1,0 +1,72 @@
+using Confluent.Kafka;
+using System;
+using System.Threading.Tasks;
+using Kafka.Ksql.Linq;
+using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq.Configuration;
+using Kafka.Ksql.Linq.Core.Configuration;
+using Xunit;
+
+using Kafka.Ksql.Linq.Core.Abstractions;
+namespace Kafka.Ksql.Linq.Tests.Integration;
+
+public class KafkaServiceDownTests
+{
+    public class Order
+    {
+        public int Id { get; set; }
+        public double Amount { get; set; }
+    }
+
+    public class OrderContext : KsqlContext
+    {
+        public OrderContext() : base(new KsqlDslOptions()) { }
+        public OrderContext(KsqlDslOptions options) : base(options) { }
+        protected override void OnModelCreating(IModelBuilder modelBuilder)
+            => modelBuilder.Entity<Order>().WithTopic("orders");
+    }
+
+    private static KsqlDslOptions CreateOptions() => new()
+    {
+        Common = new CommonSection { BootstrapServers = "localhost:9092" },
+        SchemaRegistry = new SchemaRegistrySection { Url = "http://localhost:8081" }
+    };
+
+    [KsqlDbFact]
+    [Trait("Category", "Integration")]
+    public async Task AddAsync_ShouldThrow_WhenKafkaIsDown()
+    {
+        await TestEnvironment.ResetAsync();
+        await DockerHelper.StopServiceAsync("kafka");
+
+        await using var ctx = new OrderContext(CreateOptions());
+        var msg = new Order { Id = 1, Amount = 100 };
+
+        var ex = await Assert.ThrowsAsync<KafkaException>(() =>
+            ctx.Set<Order>().AddAsync(msg));
+        Assert.Contains("refused", ex.Message, StringComparison.OrdinalIgnoreCase);
+
+        await DockerHelper.StartServiceAsync("kafka");
+        await TestEnvironment.SetupAsync();
+
+        await ctx.Set<Order>().AddAsync(new Order { Id = 2, Amount = 50 });
+    }
+
+    [KsqlDbFact]
+    [Trait("Category", "Integration")]
+    public async Task ForeachAsync_ShouldThrow_WhenKafkaIsDown()
+    {
+        await TestEnvironment.ResetAsync();
+        await DockerHelper.StopServiceAsync("kafka");
+
+        await using var ctx = new OrderContext(CreateOptions());
+
+        await Assert.ThrowsAsync<ConsumeException>(async () =>
+        {
+            await ctx.Set<Order>().ForEachAsync(_ => Task.CompletedTask, TimeSpan.FromSeconds(1));
+        });
+
+        await DockerHelper.StartServiceAsync("kafka");
+        await TestEnvironment.SetupAsync();
+    }
+}

--- a/physicalTests/DockerHelper.cs
+++ b/physicalTests/DockerHelper.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace Kafka.Ksql.Linq.Tests.Integration;
+
+internal static class DockerHelper
+{
+    private const string ComposeFile = "tools/docker-compose.kafka.yml";
+
+    public static Task StopServiceAsync(string service) =>
+        RunAsync($"docker-compose -f {ComposeFile} stop {service}");
+
+    public static async Task StartServiceAsync(string service)
+    {
+        await RunAsync($"docker-compose -f {ComposeFile} start {service}");
+        // wait briefly for service to become available
+        await Task.Delay(TimeSpan.FromSeconds(5));
+    }
+
+    private static async Task RunAsync(string command)
+    {
+        var psi = new ProcessStartInfo("bash", $"-c \"{command}\"")
+        {
+            RedirectStandardError = true,
+            RedirectStandardOutput = true
+        };
+        using var process = Process.Start(psi)!;
+        await process.WaitForExitAsync();
+        if (process.ExitCode != 0)
+        {
+            var error = await process.StandardError.ReadToEndAsync();
+            throw new InvalidOperationException(error);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add DockerHelper for controlling kafka service during tests
- add KafkaServiceDownTests for AddAsync and ForEachAsync failure cases
- log progress entry for 2025-07-22

## Testing
- `dotnet test physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_687f100a8ec08327811d780bd5ce2fa4