### PR TITLE
Add BigBang Kafka connection tests

### DIFF
--- a/physicalTests/Connectivity/BigBang_KafkaConnection_StrictTests.cs
+++ b/physicalTests/Connectivity/BigBang_KafkaConnection_StrictTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+using Kafka.Ksql.Linq;
+using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq.Configuration;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Configuration;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Integration;
+
+public class BigBang_KafkaConnection_StrictTests
+{
+    public class Order
+    {
+        public int Id { get; set; }
+        public double Amount { get; set; }
+    }
+
+    public class OrderContext : KsqlContext
+    {
+        public OrderContext() : base(new KsqlDslOptions()) { }
+        public OrderContext(KsqlDslOptions options) : base(options) { }
+        protected override void OnModelCreating(IModelBuilder modelBuilder)
+            => modelBuilder.Entity<Order>().WithTopic("orders");
+    }
+
+    private static KsqlDslOptions CreateOptions() => new()
+    {
+        Common = new CommonSection { BootstrapServers = "localhost:9092" },
+        SchemaRegistry = new SchemaRegistrySection { Url = "http://localhost:8081" }
+    };
+
+    [KsqlDbFact]
+    [Trait("Category", "Integration")]
+    public async Task EX02_AddAsync_KafkaDown_ShouldLogAndTimeout()
+    {
+        await DockerHelper.StopServiceAsync("kafka");
+        await using var ctx = new OrderContext(CreateOptions());
+        var msg = new Order { Id = 1, Amount = 100 };
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var task = ctx.Set<Order>().AddAsync(msg, null, cts.Token);
+        var completed = await Task.WhenAny(task, Task.Delay(11000));
+        Assert.Same(task, completed);
+
+        var ex = await Assert.ThrowsAsync<KafkaException>(() => task);
+        Assert.Contains("connection refused", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [KsqlDbFact]
+    [Trait("Category", "Integration")]
+    public async Task EX02_ForeachAsync_KafkaDown_ShouldLogAndTimeout()
+    {
+        await DockerHelper.StopServiceAsync("kafka");
+        await using var ctx = new OrderContext(CreateOptions());
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var task = ctx.Set<Order>().ForEachAsync(_ => Task.CompletedTask, TimeSpan.FromSeconds(1), cts.Token);
+        var completed = await Task.WhenAny(task, Task.Delay(11000));
+        Assert.Same(task, completed);
+
+        var ex = await Assert.ThrowsAsync<ConsumeException>(() => task);
+        Assert.Contains("connection", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/physicalTests/Connectivity/BigBang_KafkaConnection_TolerantTests.cs
+++ b/physicalTests/Connectivity/BigBang_KafkaConnection_TolerantTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+using Kafka.Ksql.Linq;
+using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq.Configuration;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Configuration;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Integration;
+
+public class BigBang_KafkaConnection_TolerantTests
+{
+    public class Order
+    {
+        public int Id { get; set; }
+        public double Amount { get; set; }
+    }
+
+    public class OrderContext : KsqlContext
+    {
+        public OrderContext() : base(new KsqlDslOptions()) { }
+        public OrderContext(KsqlDslOptions options) : base(options) { }
+        protected override void OnModelCreating(IModelBuilder modelBuilder)
+            => modelBuilder.Entity<Order>().WithTopic("orders");
+    }
+
+    private static KsqlDslOptions CreateOptions() => new()
+    {
+        Common = new CommonSection { BootstrapServers = "localhost:9092" },
+        SchemaRegistry = new SchemaRegistrySection { Url = "http://localhost:8081" }
+    };
+
+    [KsqlDbFact]
+    [Trait("Category", "Integration")]
+    public async Task EX01_AddAsync_KafkaDown_ShouldFailGracefully()
+    {
+        await DockerHelper.StopServiceAsync("kafka");
+        await using var ctx = new OrderContext(CreateOptions());
+        var msg = new Order { Id = 1, Amount = 100 };
+
+        var ex = await Assert.ThrowsAsync<KafkaException>(() =>
+            ctx.Set<Order>().AddAsync(msg));
+        Assert.Contains("connection", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [KsqlDbFact]
+    [Trait("Category", "Integration")]
+    public async Task EX01_ForeachAsync_KafkaDown_ShouldFailGracefully()
+    {
+        await DockerHelper.StopServiceAsync("kafka");
+        await using var ctx = new OrderContext(CreateOptions());
+
+        var ex = await Assert.ThrowsAsync<ConsumeException>(async () =>
+            await ctx.Set<Order>().ForEachAsync(_ => Task.CompletedTask, TimeSpan.FromSeconds(1)));
+        Assert.Contains("connection", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
## Summary
- add tolerant connection loss tests for AddAsync and ForEachAsync
- add strict connection loss tests checking timeout behavior

## Testing
- `dotnet build Kafka.Ksql.Linq.sln --no-restore --verbosity minimal`
- `dotnet test --no-build --verbosity minimal` *(fails: KsqlContext initialization failed)*

------
https://chatgpt.com/codex/tasks/task_e_687f72c5a89083279f4924b032891fd9