### PR TITLE
Add Kafka REST Proxy client utility

### DIFF
--- a/tests/Common/KafkaRestProxyClient.cs
+++ b/tests/Common/KafkaRestProxyClient.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Kafka.Ksql.Linq.Tests;
+
+public static class KafkaRestProxyClient
+{
+    private static readonly string BaseUrl = "http://localhost:8082";
+
+    public static async Task<string[]> FetchMessagesAsync(string topic, int partition = 0, int count = 10)
+    {
+        using var http = new HttpClient();
+        var url = $"{BaseUrl}/topics/{Uri.EscapeDataString(topic)}/partitions/{partition}/messages?count={count}";
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.kafka.json.v2+json"));
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await http.SendAsync(request).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw new KafkaRestProxyException("Failed to fetch messages from Kafka REST Proxy.", ex);
+        }
+
+        response.EnsureSuccessStatusCode();
+
+        var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        var messages = new List<string>();
+
+        using var document = JsonDocument.Parse(content);
+        foreach (var element in document.RootElement.EnumerateArray())
+        {
+            if (element.TryGetProperty("value", out var value))
+            {
+                messages.Add(value.GetRawText());
+            }
+        }
+
+        return messages.ToArray();
+    }
+}
+
+public class KafkaRestProxyException : Exception
+{
+    public KafkaRestProxyException(string message) : base(message) { }
+    public KafkaRestProxyException(string message, Exception innerException) : base(message, innerException) { }
+}


### PR DESCRIPTION
## Summary
- implement `KafkaRestProxyClient` to fetch messages via Kafka REST Proxy
- expose custom `KafkaRestProxyException`

## Testing
- `dotnet test ../Kafka.Ksql.Linq.sln --no-build -v minimal` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_687f738d9ae08327b976c88d5e9e8818