### PR TITLE
Add SendOnly and ReceiveOnly apps

### DIFF
--- a/docs/changes/20250722_progress.md
+++ b/docs/changes/20250722_progress.md
@@ -21,3 +21,5 @@
 
 ## 2025-07-22 13:30 JST [shion]
 - Kafka停止時の例外テストを追加
+## 2025-07-22 20:29 JST [assistant]
+- added SendOnly and ReceiveOnly sample apps with appsettings configuration

--- a/src/Kafka.Ksql.Linq.csproj
+++ b/src/Kafka.Ksql.Linq.csproj
@@ -17,6 +17,11 @@
     </AssemblyAttribute>
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Remove="SendOnly\**\*.cs" />
+    <Compile Remove="ReceiveOnly\**\*.cs" />
+  </ItemGroup>
+
 
 
 	<ItemGroup>

--- a/src/ReceiveOnly/KsqlDslReceiver.csproj
+++ b/src/ReceiveOnly/KsqlDslReceiver.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Kafka.Ksql.Linq.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/ReceiveOnly/Program.cs
+++ b/src/ReceiveOnly/Program.cs
@@ -1,0 +1,42 @@
+using Kafka.Ksql.Linq;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Microsoft.Extensions.Configuration;
+
+[Topic("orders")]
+public class Order
+{
+    public int Id { get; set; }
+    public decimal Amount { get; set; }
+}
+
+public class OrderContext : KsqlContext
+{
+    public OrderContext(IConfiguration configuration) : base(configuration) { }
+    protected override void OnModelCreating(IModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Order>();
+    }
+}
+
+var configuration = new ConfigurationBuilder()
+    .AddJsonFile("appsettings.json")
+    .Build();
+
+await using var context = new OrderContext(configuration);
+
+while (true)
+{
+    try
+    {
+        await context.Set<Order>().ForEachAsync(o =>
+        {
+            Console.WriteLine($"Received Order: {o.Id}");
+            return Task.CompletedTask;
+        });
+    }
+    catch (Exception ex)
+    {
+        Console.WriteLine($"Receive error: {ex.Message}");
+        await Task.Delay(1000);
+    }
+}

--- a/src/ReceiveOnly/appsettings.json
+++ b/src/ReceiveOnly/appsettings.json
@@ -1,0 +1,16 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information"
+    }
+  },
+  "KsqlDsl": {
+    "Common": {
+      "BootstrapServers": "localhost:9092",
+      "ClientId": "receiver-app"
+    },
+    "SchemaRegistry": {
+      "Url": "http://localhost:8085"
+    }
+  }
+}

--- a/src/SendOnly/KsqlDslSender.csproj
+++ b/src/SendOnly/KsqlDslSender.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Kafka.Ksql.Linq.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/SendOnly/Program.cs
+++ b/src/SendOnly/Program.cs
@@ -1,0 +1,45 @@
+using Confluent.Kafka;
+using Kafka.Ksql.Linq;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Microsoft.Extensions.Configuration;
+
+[Topic("orders")]
+public class Order
+{
+    public int Id { get; set; }
+    public decimal Amount { get; set; }
+}
+
+public class OrderContext : KsqlContext
+{
+    public OrderContext(IConfiguration configuration) : base(configuration) { }
+    protected override void OnModelCreating(IModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Order>();
+    }
+}
+
+var configuration = new ConfigurationBuilder()
+    .AddJsonFile("appsettings.json")
+    .Build();
+
+await using var context = new OrderContext(configuration);
+
+while (true)
+{
+    try
+    {
+        var order = new Order
+        {
+            Id = Random.Shared.Next(),
+            Amount = Random.Shared.Next(1, 100)
+        };
+        await context.Set<Order>().AddAsync(order);
+        Console.WriteLine($"Sent Order: {order.Id}");
+    }
+    catch (KafkaException ex)
+    {
+        Console.WriteLine($"Kafka error: {ex.Error.Reason}");
+    }
+    await Task.Delay(1000);
+}

--- a/src/SendOnly/appsettings.json
+++ b/src/SendOnly/appsettings.json
@@ -1,0 +1,16 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information"
+    }
+  },
+  "KsqlDsl": {
+    "Common": {
+      "BootstrapServers": "localhost:9092",
+      "ClientId": "sender-app"
+    },
+    "SchemaRegistry": {
+      "Url": "http://localhost:8085"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add SendOnly and ReceiveOnly console apps demonstrating separated sender/receiver processes
- exclude app sources from the main library build
- note progress log entry

## Testing
- `dotnet test --verbosity minimal` *(fails: Kafka connectivity tests)*

------
https://chatgpt.com/codex/tasks/task_e_687f73b0fa788327aeb483e0119b21aa