### PR TITLE
Rename BaseOn to BasedOn

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -32,7 +32,7 @@
 | `.Where(predicate)`            | 条件フィルタ                  | `IEventSet<T>`                    | Stream/Table  | ✅      |
 | `.Window(WindowDef \| TimeSpan)` | タイムウィンドウ指定       | `IQueryable<T>`                   | Stream        | ✅      |
 | `.Window(int minutes)`          | `WindowMinutes`によるフィルタ  | `IEntitySet<T>`                  | Stream/Table  | ✅      |
-| `.Window().BaseOn<TSchedule>(keySelector, ?openProp, ?closeProp)` | `[ScheduleRange]` 属性、または `openProp`/`closeProp` パラメータで開始/終了を示すスケジュールPOCOに基づきウィンドウを生成 | `IQueryable<T>` | Stream | ✅ |
+| `.Window().BasedOn<TSchedule>(keySelector, ?openProp, ?closeProp)` | `[ScheduleRange]` 属性、または `openProp`/`closeProp` パラメータで開始/終了を示すスケジュールPOCOに基づきウィンドウを生成 | `IQueryable<T>` | Stream | ✅ |
 | `.GroupBy(...)`                | グループ化および集約          | `IEventSet<IGrouping<TKey, T>>`   | Stream/Table  | ✅      |
 | `.OnError(ErrorAction)`        | エラー処理方針指定            | `EventSet<T>`                     | Stream        | ✅      |
 | `.WithRetry(int)`              | リトライ設定                  | `EventSet<T>`                     | Stream        | ✅      |
@@ -47,7 +47,7 @@
 - `Set<T>().Limit(n)` を指定すると n 件取得後にストリームが終了します。残りのレコードは破棄されます。
 - バーエンティティでは `WithWindow().Select<TBar>()` で `BarTime` に代入した式が自動的に記録され、`Limit` の並び替えに使用されます。
 - `RemoveAsync(key)` は値 `null` のトムストーンを送り、KTable やキャッシュから該当キーのデータを削除します。
-- `.Window().BaseOn<TSchedule>` を用いる場合、バーは `[ScheduleRange]` 属性、または `openProp`/`closeProp` パラメータで示された `Open` ～ `Close` の範囲に含まれるデータのみで構成されます。日足生成で `Close` が 6:30 のときは、6:30 未満のデータが当日の終値として扱われます。
+- `.Window().BasedOn<TSchedule>` を用いる場合、バーは `[ScheduleRange]` 属性、または `openProp`/`closeProp` パラメータで示された `Open` ～ `Close` の範囲に含まれるデータのみで構成されます。日足生成で `Close` が 6:30 のときは、6:30 未満のデータが当日の終値として扱われます。
 - バーやウィンドウ定義は必ず `KafkaKsqlContext.OnModelCreating` 内で宣言してください。アプリケーション側では定義済みの `Set<T>` を参照するだけです。
 - `WithWindow<Rate, MarketSchedule>()` に続けて `.Select<RateCandle>()` を呼び出すことで、レートからバーエンティティを構成できます。
 - `WithWindow<TEntity, TSchedule>(windows, timeSelector, rateKey, scheduleKey)` として `timeSelector` 引数でウィンドウを区切る時刻プロパティを明示します。

--- a/docs/diff_log/diff_basedon_20250731.md
+++ b/docs/diff_log/diff_basedon_20250731.md
@@ -1,0 +1,18 @@
+# 差分履歴: rename_baseon_method
+
+🗕 2025年7月31日（JST）
+🧐 作業者: naruse
+
+## 差分タイトル
+BaseOn メソッド名を BasedOn に変更
+
+## 変更理由
+API 名とドキュメントの整合性を保つため。機能自体は変わらないが名称を過去形に統一した。
+
+## 追加・修正内容（反映先: oss_design_combined.md）
+- `ScheduleWindowBuilder` の公開メソッド `BaseOn` を `BasedOn` にリネーム
+- 内部実装 `BaseOnImpl` を `BasedOnImpl` へ変更
+- テストおよびドキュメント内の利用箇所を更新
+
+## 参考文書
+- `docs/api_reference.md`

--- a/features/daily_comparison/instruction.md
+++ b/features/daily_comparison/instruction.md
@@ -55,5 +55,5 @@ broker, symbol, date, high, low, close, prev_close, diff
 - 参照プロセスから比較表を任意タイミングで閲覧できる
 
 ## 2025-07-19 02:11 JST [assistant]
-- ScheduleRange の条件を用いて DailyComparison の日足を計算する方法を明文化してください。具体的には `Window().BaseOn<TSchedule>()` でスケジュールテーブルを参照し、IF 条件で `openTime <= RateTimestamp < closeTime` を適用します。
+- ScheduleRange の条件を用いて DailyComparison の日足を計算する方法を明文化してください。具体的には `Window().BasedOn<TSchedule>()` でスケジュールテーブルを参照し、IF 条件で `openTime <= RateTimestamp < closeTime` を適用します。
 - 上記の処理を応用し、1分足、5分足、60分足の集計も同時に生成すること。必要に応じて `ScheduleRange` の範囲を分解して各分足を計算してください。

--- a/features/window/instruction.md
+++ b/features/window/instruction.md
@@ -1,7 +1,7 @@
 To naruse
 Window関数で足を作れるけど、足のclose timeは機械的に決まらないため、この機能を入れる。
 以下の要件でまず設計を行ってください。
-・Window().BaseOn<marketschedulepoco>()のIFとする
+・Window().BasedOn<marketschedulepoco>()のIFとする
 marketschedulepocoには複数のPKを持つことを想定する
 marketschedulepocoにはopen/closeの日時を持つプロパティが存在する
 区間の境界値は「左閉右開」[Open, Close)

--- a/src/EventSetScheduleWindowExtensions.cs
+++ b/src/EventSetScheduleWindowExtensions.cs
@@ -22,15 +22,15 @@ public class ScheduleWindowBuilder<T> where T : class
         _source = source;
     }
 
-    private static readonly MethodInfo BaseOnMethod = typeof(ScheduleWindowBuilder<T>)
+    private static readonly MethodInfo BasedOnMethod = typeof(ScheduleWindowBuilder<T>)
         .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
-        .Single(m => m.Name == nameof(BaseOnImpl));
+        .Single(m => m.Name == nameof(BasedOnImpl));
 
-    public IQueryable<T> BaseOn<TSchedule>(Expression<Func<T, object>> keySelector) where TSchedule : class
+    public IQueryable<T> BasedOn<TSchedule>(Expression<Func<T, object>> keySelector) where TSchedule : class
     {
         if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
         var call = Expression.Call(null,
-            BaseOnMethod.MakeGenericMethod(typeof(T), typeof(TSchedule)),
+            BasedOnMethod.MakeGenericMethod(typeof(T), typeof(TSchedule)),
             _source.Expression,
             keySelector,
             Expression.Constant(null, typeof(string)),
@@ -38,14 +38,14 @@ public class ScheduleWindowBuilder<T> where T : class
         return _source.Provider.CreateQuery<T>(call);
     }
 
-    public IQueryable<T> BaseOn<TSchedule>(Expression<Func<T, object>> keySelector, string openPropertyName, string closePropertyName) where TSchedule : class
+    public IQueryable<T> BasedOn<TSchedule>(Expression<Func<T, object>> keySelector, string openPropertyName, string closePropertyName) where TSchedule : class
     {
         if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
         if (string.IsNullOrWhiteSpace(openPropertyName) || string.IsNullOrWhiteSpace(closePropertyName))
             throw new ArgumentException("Property names cannot be null or empty");
 
         var call = Expression.Call(null,
-            BaseOnMethod.MakeGenericMethod(typeof(T), typeof(TSchedule)),
+            BasedOnMethod.MakeGenericMethod(typeof(T), typeof(TSchedule)),
             _source.Expression,
             keySelector,
             Expression.Constant(openPropertyName, typeof(string)),
@@ -53,12 +53,12 @@ public class ScheduleWindowBuilder<T> where T : class
         return _source.Provider.CreateQuery<T>(call);
     }
 
-    private static IQueryable<TSource> BaseOnImpl<TSource, TSchedule>(IQueryable<TSource> source, Expression<Func<TSource, object>> keySelector, string? openPropertyName, string? closePropertyName)
+    private static IQueryable<TSource> BasedOnImpl<TSource, TSchedule>(IQueryable<TSource> source, Expression<Func<TSource, object>> keySelector, string? openPropertyName, string? closePropertyName)
         where TSource : class
         where TSchedule : class
     {
         if (source is not Core.Abstractions.IEntitySet<TSource> entitySet)
-            throw new NotSupportedException("BaseOn can only be used on IEntitySet sources.");
+            throw new NotSupportedException("BasedOn can only be used on IEntitySet sources.");
 
         var context = entitySet.GetContext();
         var scheduleSetObj = context.GetEventSet(typeof(TSchedule));

--- a/tests/Extensions/ScheduleWindowBuilderTests.cs
+++ b/tests/Extensions/ScheduleWindowBuilderTests.cs
@@ -39,41 +39,41 @@ public class ScheduleWindowBuilderTests
     }
 
     [Fact]
-    public void Window_BaseOn_BuildsMethodCall()
+    public void Window_BasedOn_BuildsMethodCall()
     {
         IQueryable<TestEntity> src = new List<TestEntity>().AsQueryable();
 
-        var query = src.Window().BaseOn<ScheduleEntity>(e => e.MarketId);
+        var query = src.Window().BasedOn<ScheduleEntity>(e => e.MarketId);
         var call = Assert.IsAssignableFrom<MethodCallExpression>(query.Expression);
-        Assert.Equal("BaseOnImpl", call.Method.Name);
+        Assert.Equal("BasedOnImpl", call.Method.Name);
         var genArgs = call.Method.GetGenericArguments();
         Assert.Equal(typeof(TestEntity), genArgs[0]);
         Assert.Equal(typeof(ScheduleEntity), genArgs[1]);
     }
 
     [Fact]
-    public void BaseOn_NullSelector_Throws()
+    public void BasedOn_NullSelector_Throws()
     {
         IQueryable<TestEntity> src = new List<TestEntity>().AsQueryable();
-        Assert.Throws<ArgumentNullException>(() => src.Window().BaseOn<ScheduleEntity>(null!));
+        Assert.Throws<ArgumentNullException>(() => src.Window().BasedOn<ScheduleEntity>(null!));
     }
 
     [Fact]
-    public void BaseOnImpl_NonEntitySet_Throws()
+    public void BasedOnImpl_NonEntitySet_Throws()
     {
         IQueryable<TestEntity> src = new List<TestEntity>().AsQueryable();
         Expression<Func<TestEntity, object>> selector = e => e.MarketId;
 
         var method = typeof(ScheduleWindowBuilder<TestEntity>)
             .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
-            .Single(m => m.Name == "BaseOnImpl")
+            .Single(m => m.Name == "BasedOnImpl")
             .MakeGenericMethod(typeof(TestEntity), typeof(ScheduleEntity));
         var ex = Assert.Throws<TargetInvocationException>(() => method.Invoke(null, new object?[] { src, selector, null, null }));
         Assert.IsType<NotSupportedException>(ex.InnerException);
     }
 
     [Fact]
-    public void BaseOnImpl_FluentScheduleRange_Works()
+    public void BasedOnImpl_FluentScheduleRange_Works()
     {
         var ctx = new DummyContext();
         var eventModel = new EntityModel { EntityType = typeof(TestEntity), AllProperties = typeof(TestEntity).GetProperties(), KeyProperties = Array.Empty<PropertyInfo>(), ValidationResult = new ValidationResult { IsValid = true } };
@@ -86,7 +86,7 @@ public class ScheduleWindowBuilderTests
 
         var method = typeof(ScheduleWindowBuilder<TestEntity>)
             .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
-            .Single(m => m.Name == "BaseOnImpl")
+            .Single(m => m.Name == "BasedOnImpl")
             .MakeGenericMethod(typeof(TestEntity), typeof(FluentScheduleEntity));
 
         var result = method.Invoke(null, new object?[] { events, selector, "Start", "End" });
@@ -139,7 +139,7 @@ public class ScheduleWindowBuilderTests
     }
 
     [Fact]
-    public void BaseOnImpl_MissingScheduleRange_Throws()
+    public void BasedOnImpl_MissingScheduleRange_Throws()
     {
         var ctx = new DummyContext();
         var eventModel = new EntityModel { EntityType = typeof(TestEntity), AllProperties = typeof(TestEntity).GetProperties(), KeyProperties = Array.Empty<PropertyInfo>(), ValidationResult = new ValidationResult { IsValid = true } };
@@ -152,7 +152,7 @@ public class ScheduleWindowBuilderTests
 
         var method = typeof(ScheduleWindowBuilder<TestEntity>)
             .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
-            .Single(m => m.Name == "BaseOnImpl")
+            .Single(m => m.Name == "BasedOnImpl")
             .MakeGenericMethod(typeof(TestEntity), typeof(BadSchedule));
         var ex = Assert.Throws<TargetInvocationException>(() => method.Invoke(null, new object?[] { events, selector, null, null }));
         Assert.IsType<InvalidOperationException>(ex.InnerException);


### PR DESCRIPTION
## Summary
- rename `BaseOn` methods to `BasedOn`
- update docs referencing the method name
- adjust tests for the renamed API
- document the change in a new diff log

## Testing
- `dotnet build tests/Kafka.Ksql.Linq.Tests.csproj -c Release`
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj` *(fails: Schema Registry not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_687fa8904cd48327bac0953ed5ae0dc3