### PR TITLE
Add integration tests for DLQ and ksqlDB outages

### DIFF
--- a/docs/changes/20250731_progress.md
+++ b/docs/changes/20250731_progress.md
@@ -131,3 +131,5 @@
 - restored GetDefaultKsqlDbUrl logic to check SchemaRegistry then BootstrapServers
 ## 2025-07-21 12:38 JST [assistant]
 - removed BootstrapServers fallback; SchemaRegistry URL must be set for ksqlDB
+## 2025-07-23 08:15 JST [sion]
+- added integration tests for DLQ, ksqlDB outage, advanced data types, dummy flag skipping, and invalid KSQL

--- a/physicalTests/Connectivity/KsqlDbServiceDownTests.cs
+++ b/physicalTests/Connectivity/KsqlDbServiceDownTests.cs
@@ -1,0 +1,28 @@
+using Confluent.Kafka;
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Kafka.Ksql.Linq;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Integration;
+
+public class KsqlDbServiceDownTests
+{
+    [KsqlDbFact]
+    [Trait("Category", "Integration")]
+    public async Task ExecuteStatement_ShouldFail_WhenKsqlDbDown()
+    {
+        await TestEnvironment.ResetAsync();
+        await DockerHelper.StopServiceAsync("ksqldb-server");
+
+        await using var ctx = TestEnvironment.CreateContext();
+        await Assert.ThrowsAsync<HttpRequestException>(async () =>
+        {
+            await ctx.ExecuteStatementAsync("SHOW TOPICS;");
+        });
+
+        await DockerHelper.StartServiceAsync("ksqldb-server");
+        await TestEnvironment.SetupAsync();
+    }
+}

--- a/physicalTests/KsqlSyntax/InvalidQueryTests.cs
+++ b/physicalTests/KsqlSyntax/InvalidQueryTests.cs
@@ -1,0 +1,21 @@
+using Kafka.Ksql.Linq.Application;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Integration;
+
+public class InvalidQueryTests
+{
+    [KsqlDbTheory]
+    [Trait("Category", "Integration")]
+    [InlineData("SELECT ID, COUNT(*) FROM ORDERS GROUP BY ID;")]
+    [InlineData("SELECT CASE WHEN ID=1 THEN 'A' ELSE 2 END FROM ORDERS EMIT CHANGES;")]
+    public async Task GeneratedQuery_IsRejected(string ksql)
+    {
+        await TestEnvironment.ResetAsync();
+
+        await using var ctx = TestEnvironment.CreateContext();
+        var response = await ctx.ExecuteExplainAsync(ksql);
+        Assert.False(response.IsSuccess, $"{ksql} unexpectedly succeeded");
+    }
+}

--- a/physicalTests/OssSamples/AdvancedDataTypeTests.cs
+++ b/physicalTests/OssSamples/AdvancedDataTypeTests.cs
@@ -1,0 +1,60 @@
+using Confluent.Kafka;
+using Kafka.Ksql.Linq;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Configuration;
+using Kafka.Ksql.Linq.Core.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Integration;
+
+public class AdvancedDataTypeTests
+{
+    public enum Status { Pending, Done }
+
+    public class Record
+    {
+        public int Id { get; set; }
+        public decimal Price { get; set; }
+        public DateTime Created { get; set; }
+        public Status State { get; set; }
+    }
+
+    public class RecordContext : KsqlContext
+    {
+        public RecordContext() : base(new KsqlDslOptions()) { }
+        public RecordContext(KsqlDslOptions options) : base(options) { }
+        protected override void OnModelCreating(IModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Record>()
+                .WithTopic("records")
+                .WithDecimalPrecision(r => r.Price, precision: 18, scale: 4);
+        }
+    }
+
+    [KsqlDbFact]
+    [Trait("Category", "Integration")]
+    public async Task Decimal_DateTime_Enum_RoundTrip()
+    {
+        await TestEnvironment.ResetAsync();
+
+        var options = new KsqlDslOptions
+        {
+            Common = new CommonSection { BootstrapServers = "localhost:9092" },
+            SchemaRegistry = new SchemaRegistrySection { Url = "http://localhost:8088" }
+        };
+
+        await using var ctx = new RecordContext(options);
+
+        var data = new Record { Id = 1, Price = 12.3456m, Created = DateTime.UtcNow, State = Status.Done };
+        await ctx.Set<Record>().AddAsync(data);
+
+        var list = await ctx.Set<Record>().ToListAsync();
+        Assert.Single(list);
+        Assert.Equal(data.Price, list[0].Price);
+        Assert.Equal(data.State, list[0].State);
+        Assert.True(Math.Abs((list[0].Created - data.Created).TotalMinutes) < 1);
+    }
+}

--- a/physicalTests/OssSamples/DlqIntegrationTests.cs
+++ b/physicalTests/OssSamples/DlqIntegrationTests.cs
@@ -1,0 +1,70 @@
+using Confluent.Kafka;
+using Kafka.Ksql.Linq;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Configuration;
+using Kafka.Ksql.Linq.Core.Configuration;
+using Kafka.Ksql.Linq.Core.Models;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Integration;
+
+public class DlqIntegrationTests
+{
+    public class Order
+    {
+        public int Id { get; set; }
+        public decimal Amount { get; set; }
+    }
+
+    public class OrderContext : KsqlContext
+    {
+        public OrderContext() : base(new KsqlDslOptions()) { }
+        public OrderContext(KsqlDslOptions options) : base(options) { }
+        protected override void OnModelCreating(IModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Order>()
+                .WithTopic("orders")
+                .WithDecimalPrecision(o => o.Amount, precision: 18, scale: 2);
+        }
+    }
+
+    [KsqlDbFact]
+    [Trait("Category", "Integration")]
+    public async Task FailingForEach_SendsToDlq()
+    {
+        await TestEnvironment.ResetAsync();
+
+        var options = new KsqlDslOptions
+        {
+            Common = new CommonSection { BootstrapServers = "localhost:9092" },
+            SchemaRegistry = new SchemaRegistrySection { Url = "http://localhost:8088" }
+        };
+
+        await using var ctx = new OrderContext(options);
+
+        // send invalid raw message to trigger deserialization failure
+        var conf = new ProducerConfig { BootstrapServers = "localhost:9092" };
+        using (var producer = new ProducerBuilder<Null, string>(conf).Build())
+        {
+            await producer.ProduceAsync("orders", new Message<Null, string> { Value = "bad" });
+            producer.Flush(TimeSpan.FromSeconds(5));
+        }
+
+        // consuming with typed context will cause DLQ forwarding
+        await ctx.Set<Order>().ToListAsync();
+
+        var builder = ctx.CreateConsumerBuilder<DlqEnvelope>();
+        using var consumer = builder
+            .SetErrorHandler((_, _) => { })
+            .Build();
+        consumer.Subscribe(ctx.GetDlqTopicName());
+        var dlqMsg = consumer.Consume(TimeSpan.FromSeconds(10));
+        consumer.Close();
+
+        Assert.NotNull(dlqMsg);
+        Assert.NotEmpty(dlqMsg.Message.Value.ErrorType);
+    }
+}

--- a/physicalTests/OssSamples/DummyFlagSkipTests.cs
+++ b/physicalTests/OssSamples/DummyFlagSkipTests.cs
@@ -1,0 +1,72 @@
+using Confluent.Kafka;
+using Kafka.Ksql.Linq;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Configuration;
+using Kafka.Ksql.Linq.Core.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Integration;
+
+public class DummyFlagSkipTests
+{
+    public class Order
+    {
+        public int Id { get; set; }
+        public string Region { get; set; } = string.Empty;
+        public double Amount { get; set; }
+        public int Count { get; set; }
+    }
+
+    public class DummyContext : KsqlContext
+    {
+        public DummyContext() : base(new KsqlDslOptions()) { }
+        public DummyContext(KsqlDslOptions options) : base(options) { }
+        protected override void OnModelCreating(IModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Order>().WithTopic("orders");
+        }
+    }
+
+    [KsqlDbFact]
+    [Trait("Category", "Integration")]
+    public async Task Consumer_IgnoresDummyMessages()
+    {
+        await TestEnvironment.ResetAsync();
+
+        var options = new KsqlDslOptions
+        {
+            Common = new CommonSection { BootstrapServers = "localhost:9092" },
+            SchemaRegistry = new SchemaRegistrySection { Url = "http://localhost:8088" }
+        };
+
+        await using var ctx = new DummyContext(options);
+
+        var headers = new Dictionary<string, string> { ["is_dummy"] = "true" };
+        await ctx.Set<Order>().AddAsync(new Order { Id = 1, Region = "east", Amount = 1, Count = 1 }, headers);
+        await ctx.Set<Order>().AddAsync(new Order { Id = 2, Region = "east", Amount = 2, Count = 1 });
+
+        var builder = ctx.CreateConsumerBuilder<Order>();
+        using var consumer = builder.SetErrorHandler((_, _) => { }).Build();
+        consumer.Subscribe(ctx.GetTopicName<Order>());
+
+        var received = new List<Order>();
+        var end = DateTime.UtcNow.AddSeconds(10);
+        while (DateTime.UtcNow < end && received.Count < 1)
+        {
+            var msg = consumer.Consume(TimeSpan.FromSeconds(1));
+            if (msg == null) continue;
+            var dummyHeader = msg.Message.Headers?.GetLastBytes("is_dummy");
+            var isDummy = dummyHeader != null && Encoding.UTF8.GetString(dummyHeader) == "true";
+            if (!isDummy)
+                received.Add(msg.Message.Value);
+        }
+        consumer.Close();
+
+        Assert.Single(received);
+        Assert.Equal(2, received[0].Id);
+    }
+}


### PR DESCRIPTION
## Summary
- expand progress log
- add integration test covering DLQ forwarding on deserialization errors
- add ksqlDB outage handling test
- verify decimal, DateTime and enum round-trips
- skip dummy messages by inspecting Kafka headers
- confirm invalid queries are rejected by ksqlDB

## Testing
- `dotnet test physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj --filter Category=Integration` *(tests skipped in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_688019760fb483278cfbec7e6462881d