### PR TITLE
Add logging guidelines

### DIFF
--- a/docs/docs_advanced_rules.md
+++ b/docs/docs_advanced_rules.md
@@ -142,6 +142,7 @@ modelBuilder.Entity<RateCandle>()
 
 本OSSでは、Kafkaやストリーム処理に関連するメトリック収集は**Confluent公式クライアントパッケージ（Confluent.Kafka）**側の機能を利用する方針とします。  
 OSS本体はアプリケーション側の運用情報・エラー通知等を**ILogger等の標準ロギング機構**で出力します。
+ログメッセージの表記ルールは [logging_guidelines.md](logging_guidelines.md) を参照してください。
 
 - Kafkaパフォーマンス・レイテンシ・メッセージ数などの詳細メトリックは、Confluent.Kafkaが標準で提供する監視API・メトリック機能を活用してください。
 - OSS本体で追加するのは「運用ログ（状態・エラー・イベント）」のみです。

--- a/docs/logging_guidelines.md
+++ b/docs/logging_guidelines.md
@@ -1,0 +1,13 @@
+# Logging Guidelines
+
+This project uses structured logging throughout the code base. The following conventions keep log output predictable and easy to grep:
+
+- **Sentence case:** Start each message with a capital letter.
+- **No emoji or decorative punctuation.**
+- **One sentence per message.** Do not end with a period.
+- **Success messages:** `Action succeeded: {Detail}`
+- **Failure messages:** `Failed to {action}: {Reason}`
+- **Placeholders** use PascalCase inside braces (e.g., `{TopicName}`).
+- Keep wording concise; avoid abbreviations like "SKIP".
+
+These rules apply to all log calls in `src/`.

--- a/src/KsqlContext.cs
+++ b/src/KsqlContext.cs
@@ -298,6 +298,7 @@ public abstract class KsqlContext : IKsqlContext
             await _adminService.EnsureWindowFinalTopicsExistAsync(GetEntityModels());
 
             // Log output: DLQ preparation complete
+            // TODO: Standardize wording per logging_guidelines.md
             Logger.LogInformation("✅ Kafka initialization completed. DLQ topic '{Topic}' is ready with 5-second retention.", GetDlqTopicName());
         }
         catch (Exception ex)

--- a/src/Messaging/Consumers/KafkaConsumerManager.cs
+++ b/src/Messaging/Consumers/KafkaConsumerManager.cs
@@ -367,6 +367,7 @@ internal class KafkaConsumerManager : IDisposable
     {
         if (!_disposed)
         {
+            // TODO: Remove ellipsis per logging_guidelines.md
             _logger?.LogInformation("Disposing type-safe KafkaConsumerManager...");
 
             // Consumerの解放

--- a/src/Messaging/Internal/ErrorHandlingContext.cs
+++ b/src/Messaging/Internal/ErrorHandlingContext.cs
@@ -66,6 +66,7 @@ public class ErrorHandlingContext
             }
             catch (Exception handlerEx)
             {
+                // TODO: Standardize log message per logging_guidelines.md
                 Logger.LogError(handlerEx, "CUSTOM_HANDLER_ERROR");
                 return false; // Skip if custom handler throws
             }
@@ -75,6 +76,7 @@ public class ErrorHandlingContext
         {
             case ErrorAction.Skip:
                 // Log the error and skip
+                // TODO: Replace with "Skipping item after error" per logging_guidelines.md
                 Logger.LogWarning(exception, "SKIP");
                 return false; // Skip
 
@@ -115,6 +117,7 @@ public class ErrorHandlingContext
 
             default:
                 // Skip if action is unknown
+                // TODO: Reword to "Unknown error action: {Action}; skipping item" per logging_guidelines.md
                 Logger.LogError("UNKNOWN ERROR ACTION: {Action}, skipping item", ErrorAction);
                 return false;
         }

--- a/src/Messaging/Producers/KafkaProducerManager.cs
+++ b/src/Messaging/Producers/KafkaProducerManager.cs
@@ -387,6 +387,7 @@ internal class KafkaProducerManager : IDisposable
     {
         if (!_disposed)
         {
+            // TODO: Remove ellipsis per logging_guidelines.md
             _logger?.LogInformation("Disposing type-safe KafkaProducerManager...");
 
             // Producerの解放


### PR DESCRIPTION
## Summary
- document standard logging messages
- reference new guidelines from advanced rules
- add TODO notes where logs break the style

## Testing
- `dotnet test` *(fails: Kafka connectivity tests)*

------
https://chatgpt.com/codex/tasks/task_e_6880679014c08327a40294731ed60edf