### PR TITLE
Improve physical test connectivity checks

### DIFF
--- a/docs/changes/20250723_progress.md
+++ b/docs/changes/20250723_progress.md
@@ -12,3 +12,6 @@
 - `Order` 型名衝突を回避するためテストでエイリアスを利用
 ## 2025-07-23 08:15 JST [codex]
 - log出力内容の抽出スクリプト `tools/extract_log_messages.py` を追加し、`reports/log_messages_list.md` に出力を生成
+## 2025-07-23 11:33 JST [codex]
+- Improved connectivity check logging in TestEnvironment
+- Fixed Schema Registry URL usage in service checks


### PR DESCRIPTION
## Summary
- make `TestEnvironment` log specific failures per service
- fix schema registry URL check
- record progress

## Testing
- `dotnet test physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj --filter Category=Integration`

------
https://chatgpt.com/codex/tasks/task_e_6880c7d43a588327bd1df51dec312463