### PR TITLE
Add explicit test ordering

### DIFF
--- a/docs/changes/20250723_progress.md
+++ b/docs/changes/20250723_progress.md
@@ -19,3 +19,7 @@
 =======
 ## 2025-07-23 20:06 JST [assistant]
 - Updated log messages to follow guidelines and regenerated log report
+## 2025-07-23 22:21 JST [assistant]
+- Defined execution order for connectivity tests and implemented PriorityOrderer
+## 2025-07-23 13:28 JST [assistant]
+- Documented verification points for connectivity tests and updated README

--- a/physicalTests/Connectivity/PortConnectivityTests.cs
+++ b/physicalTests/Connectivity/PortConnectivityTests.cs
@@ -1,0 +1,39 @@
+using Confluent.Kafka;
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Kafka.Ksql.Linq.Application;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Integration;
+
+[TestCaseOrderer("Kafka.Ksql.Linq.Tests.Integration.PriorityOrderer", "Kafka.Ksql.Linq.Tests.Integration")]
+public class PortConnectivityTests
+{
+[Fact]
+[TestPriority(1)]
+    public void Kafka_Broker_Should_Be_Reachable()
+    {
+        using var admin = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:9092" }).Build();
+        var meta = admin.GetMetadata(TimeSpan.FromSeconds(10));
+        Assert.NotEmpty(meta.Brokers);
+    }
+
+[Fact]
+[TestPriority(2)]
+    public async Task SchemaRegistry_Should_Be_Reachable()
+    {
+        using var http = new HttpClient();
+        var resp = await http.GetAsync("http://localhost:8081/subjects");
+        Assert.True(resp.IsSuccessStatusCode);
+    }
+
+[Fact]
+[TestPriority(3)]
+    public async Task KsqlDb_Should_Be_Reachable()
+    {
+        await using var ctx = TestEnvironment.CreateContext();
+        var result = await ctx.ExecuteStatementAsync("SHOW TOPICS;");
+        Assert.True(result.IsSuccess);
+    }
+}

--- a/physicalTests/Connectivity/README.md
+++ b/physicalTests/Connectivity/README.md
@@ -1,4 +1,27 @@
 # Connectivity Tests
 
-Kafka, ksqlDB and Schema Registry connectivity checks.
-A simple producer/consumer round trip confirms the cluster is accessible.
+These tests validate that each service in the docker environment is reachable.
+Run them sequentially so any failure clearly indicates which component is
+unavailable.
+
+## Recommended order and verification points
+
+1. **PortConnectivityTests** – confirm each service port responds
+   - `Kafka_Broker_Should_Be_Reachable` &mdash; connect via Kafka Admin client
+   - `SchemaRegistry_Should_Be_Reachable` &mdash; HTTP GET to Schema Registry
+   - `KsqlDb_Should_Be_Reachable` &mdash; execute a simple statement against ksqlDB
+
+2. **KafkaConnectivityTests** – ensure producer/consumer round trip works and ksqlDB metadata is accessible
+
+3. **SchemaRegistryResetTests** – after `TestEnvironment.ResetAsync` all schemas should exist, duplicate registration should succeed and no upper‑case subjects remain
+
+4. **KafkaServiceDownTests** – verify operations throw when Kafka is stopped
+
+5. **KsqlDbServiceDownTests** – verify statements fail when ksqlDB is stopped
+
+6. **BigBang_KafkaConnection_TolerantTests** – operations immediately fail with clear errors while Kafka is down
+
+7. **BigBang_KafkaConnection_StrictTests** – operations keep retrying until timeout when Kafka is down
+
+The individual port checks are defined in `PortConnectivityTests.cs`. A basic
+producer/consumer round trip is provided in `KafkaConnectivityTests.cs` once all ports respond.

--- a/physicalTests/PriorityOrderer.cs
+++ b/physicalTests/PriorityOrderer.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Kafka.Ksql.Linq.Tests.Integration;
+
+/// <summary>
+/// Specifies the execution order for a test case.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+public sealed class TestPriorityAttribute : Attribute
+{
+    public TestPriorityAttribute(int priority) => Priority = priority;
+    public int Priority { get; }
+}
+
+/// <summary>
+/// Orders test cases by the <see cref="TestPriorityAttribute"/> value.
+/// </summary>
+public sealed class PriorityOrderer : ITestCaseOrderer
+{
+    public IEnumerable<TTestCase> OrderTestCases<TTestCase>(IEnumerable<TTestCase> testCases) where TTestCase : ITestCase
+    {
+        var sorted = testCases.OrderBy(tc =>
+        {
+            var attr = tc.TestMethod.Method.GetCustomAttributes(typeof(TestPriorityAttribute).AssemblyQualifiedName!).FirstOrDefault();
+            return attr == null ? 0 : attr.GetNamedArgument<int>("priority");
+        });
+        return sorted;
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement PriorityOrderer with TestPriorityAttribute
- enforce ordered execution in PortConnectivityTests
- document full sequence for all connectivity tests
- clarify verification points in connectivity README

## Testing
- `dotnet test physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj --filter FullyQualifiedName~PortConnectivityTests --no-build --verbosity normal` *(succeeds: no tests executed)*

------
https://chatgpt.com/codex/tasks/task_e_6880ddc6945c832793e29d84ef531f0f