### PR TITLE
Improve ksqlDB availability check

### DIFF
--- a/docs/changes/20250724_progress.md
+++ b/docs/changes/20250724_progress.md
@@ -1,0 +1,2 @@
+## 2025-07-24 00:20 JST [assistant]
+- Improved KsqlDbAvailability checks with retries and timestamped failures.


### PR DESCRIPTION
## Summary
- retry ksqlDB availability check with backoff instead of caching one result
- add progress log entry for today

## Testing
- `dotnet test` *(fails: Kafka connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6880fd4c67ac83279512ac1bd5937612