### PR TITLE
Fix missing brace in DynamicKsqlGenerationTests

### DIFF
--- a/physicalTests/KsqlSyntax/DynamicKsqlGenerationTests.cs
+++ b/physicalTests/KsqlSyntax/DynamicKsqlGenerationTests.cs
@@ -222,6 +222,7 @@ public class DynamicKsqlGenerationTests
             .Select(g => new { RegionUpper = g.Key, TotalAmount = g.Sum(x => (double)x.Amount) })
             .ToQueryString());
     }
+}
 
     // OnModelCreating で生成したモデルから DDL/DML が正しく実行できるか検証
     [Fact]


### PR DESCRIPTION
## Summary
- restore compilation by closing GenerateDmlQueries method

## Testing
- `dotnet build Kafka.Ksql.Linq.sln --no-restore -c Release`
- `dotnet test Kafka.Ksql.Linq.sln --no-build -c Release` *(fails: KsqlContext initialization failed)*

------
https://chatgpt.com/codex/tasks/task_e_688126dee0d08327a6b609fd03ff9742