### PR TITLE
Extend schema registration wait time

### DIFF
--- a/docs/changes/20250724_progress.md
+++ b/docs/changes/20250724_progress.md
@@ -9,3 +9,5 @@
 - Wrapped DynamicKsqlGenerationTests.GenerateDmlQueries in ModelCreatingScope to
   fix scope error.
 - Unit tests still fail locally due to missing Kafka services.
+## 2025-07-24 08:24 JST [assistant]
+- extend schema registration wait time to improve reliability

--- a/physicalTests/TestEnvironment.cs
+++ b/physicalTests/TestEnvironment.cs
@@ -239,7 +239,7 @@ internal static class TestEnvironment
         }
     }
 
-    private static async Task ValidateSchemaRegistrationAsync(int attempts = 5, int delayMs = 1000)
+    private static async Task ValidateSchemaRegistrationAsync(int attempts = 10, int delayMs = 2000)
     {
         var expected = TestSchema.AllTopicNames
             .SelectMany(n => new[] {$"{n}-value", $"{n}-key"})


### PR DESCRIPTION
## Summary
- increase retry attempts and delay when verifying schema registry
- log progress for 2025-07-24

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --no-build` *(fails: Failed to send entity Order to Kafka)*

------
https://chatgpt.com/codex/tasks/task_e_68816dd3cb948327888e77e7e847e893