### PR TITLE
Fix integration setup timing

### DIFF
--- a/docs/changes/20250731_progress.md
+++ b/docs/changes/20250731_progress.md
@@ -133,3 +133,5 @@
 - removed BootstrapServers fallback; SchemaRegistry URL must be set for ksqlDB
 ## 2025-07-23 08:15 JST [sion]
 - added integration tests for DLQ, ksqlDB outage, advanced data types, dummy flag skipping, and invalid KSQL
+## 2025-07-24 08:24 JST [assistant]
+- improved schema setup retries and validation

--- a/physicalTests/TestEnvironment.cs
+++ b/physicalTests/TestEnvironment.cs
@@ -102,7 +102,11 @@ internal static class TestEnvironment
 
         foreach (var ddl in TestSchema.GenerateTableDdls())
         {
-            await ctx.ExecuteStatementAsync(ddl);
+            var result = await ctx.ExecuteStatementAsync(ddl);
+            if (!result.IsSuccess)
+            {
+                throw new InvalidOperationException($"Failed to execute DDL: {ddl} - {result.Message}");
+            }
         }
 
         await ValidateSchemaRegistrationAsync();
@@ -239,7 +243,7 @@ internal static class TestEnvironment
         }
     }
 
-    private static async Task ValidateSchemaRegistrationAsync(int attempts = 5, int delayMs = 1000)
+    private static async Task ValidateSchemaRegistrationAsync(int attempts = 10, int delayMs = 1500)
     {
         var expected = TestSchema.AllTopicNames
             .SelectMany(n => new[] {$"{n}-value", $"{n}-key"})


### PR DESCRIPTION
## Summary
- validate DDL execution in TestEnvironment
- retry schema registration longer
- document progress update

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj -v n` *(fails: VSTest task returned false)*

------
https://chatgpt.com/codex/tasks/task_e_68816dec94808327a1ccacb5475157f2