### PR TITLE
Fix schema registration in integration setup

### DIFF
--- a/physicalTests/TestEnvironment.cs
+++ b/physicalTests/TestEnvironment.cs
@@ -12,6 +12,7 @@ using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.Core.Configuration;
 using System.Threading.Tasks;
+using Kafka.Ksql.Linq.Entities.Samples.Models;
 
 namespace Kafka.Ksql.Linq.Tests.Integration;
 
@@ -107,6 +108,24 @@ internal static class TestEnvironment
             {
                 throw new InvalidOperationException($"Failed to execute DDL: {ddl} - {result.Message}");
             }
+        }
+
+        // Ensure schemas for composite key tables are registered
+        var dummyOptions = new KsqlDslOptions
+        {
+            Common = new CommonSection { BootstrapServers = KafkaBootstrapServers },
+            SchemaRegistry = new SchemaRegistrySection { Url = SchemaRegistryUrl }
+        };
+        await using (var orderCtx = new CompositeKeyPocoTests.OrderContext(dummyOptions))
+        {
+            await orderCtx.Set<Order>().AddAsync(new Order
+            {
+                OrderId = 0,
+                UserId = 0,
+                ProductId = 0,
+                Quantity = 0
+            });
+            await Task.Delay(500);
         }
 
         await ValidateSchemaRegistrationAsync();


### PR DESCRIPTION
## Summary
- register schemas for composite-key table by sending a dummy message during test setup

## Testing
- `dotnet build physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj -c Release`
- `dotnet test physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj --no-build --filter Category=Integration -c Release` *(fails: KsqlContext initialization failed)*

------
https://chatgpt.com/codex/tasks/task_e_6881716ae74483278fa56231fc42b034