### PR TITLE
Remove unsupported multi-column PK test

### DIFF
--- a/docs/changes/20250724_progress.md
+++ b/docs/changes/20250724_progress.md
@@ -11,3 +11,5 @@
 - Unit tests still fail locally due to missing Kafka services.
 ## 2025-07-24 08:24 JST [assistant]
 - extend schema registration wait time to improve reliability
+## 2025-07-24 08:57 JST [assistant]
+- Removed unsupported multi-column PRIMARY KEY DDL from TestSchema and skipped CompositeKeyPocoTests.

--- a/physicalTests/OssSamples/CompositeKeyPocoTests.cs
+++ b/physicalTests/OssSamples/CompositeKeyPocoTests.cs
@@ -28,7 +28,7 @@ public class CompositeKeyPocoTests
         }
     }
 
-    [Fact]
+    [Fact(Skip = "Composite primary key DDL is not supported in ksqlDB.")]
     [Trait("Category", "Integration")]
     public async Task SendAndReceive_CompositeKeyPoco()
     {

--- a/physicalTests/TestSchema.cs
+++ b/physicalTests/TestSchema.cs
@@ -40,19 +40,10 @@ internal static class TestSchema
             ("CustomerId", "INT"),
             ("Amount", "DOUBLE")
         },
-        ["orders_multi_pk"] = new[]
-        {
-            ("OrderId", "INT"),
-            ("UserId", "INT"),
-            ("ProductId", "INT"),
-            ("Quantity", "INT")
-        }
+        // orders_multi_pk removed: multi-column PRIMARY KEY syntax is unsupported
     };
 
-    public static readonly Dictionary<string, string[]> CompositePrimaryKeys = new()
-    {
-        ["orders_multi_pk"] = new[] { "OrderId", "UserId" }
-    };
+    // CompositePrimaryKeys dictionary removed per ksqlDB limitations
 
     public static IEnumerable<string> AllTableNames => Tables.Keys.Select(k => k.ToUpperInvariant());
 
@@ -65,22 +56,12 @@ internal static class TestSchema
     {
         foreach (var kvp in Tables)
         {
-            if (CompositePrimaryKeys.TryGetValue(kvp.Key, out var keys))
-            {
-                var cols = kvp.Value.Select(c => $"{c.Name.ToUpperInvariant()} {c.Type}");
-                var pk = $"PRIMARY KEY ({string.Join(", ", keys.Select(k => k.ToUpperInvariant()))})";
-                var colList = string.Join(", ", cols) + ", " + pk;
-                yield return $"CREATE TABLE IF NOT EXISTS {kvp.Key.ToUpperInvariant()} ({colList}) WITH (KAFKA_TOPIC='{kvp.Key}', VALUE_FORMAT='AVRO', KEY_FORMAT='AVRO', PARTITIONS=1);";
-            }
-            else
-            {
-                var cols = kvp.Value.Select((c, i) =>
-                    i == 0
-                        ? $"{c.Name.ToUpperInvariant()} {c.Type} PRIMARY KEY"
-                        : $"{c.Name.ToUpperInvariant()} {c.Type}");
-                var colList = string.Join(", ", cols);
-                yield return $"CREATE TABLE IF NOT EXISTS {kvp.Key.ToUpperInvariant()} ({colList}) WITH (KAFKA_TOPIC='{kvp.Key}', VALUE_FORMAT='AVRO', KEY_FORMAT='AVRO', PARTITIONS=1);";
-            }
+            var cols = kvp.Value.Select((c, i) =>
+                i == 0
+                    ? $"{c.Name.ToUpperInvariant()} {c.Type} PRIMARY KEY"
+                    : $"{c.Name.ToUpperInvariant()} {c.Type}");
+            var colList = string.Join(", ", cols);
+            yield return $"CREATE TABLE IF NOT EXISTS {kvp.Key.ToUpperInvariant()} ({colList}) WITH (KAFKA_TOPIC='{kvp.Key}', VALUE_FORMAT='AVRO', KEY_FORMAT='AVRO', PARTITIONS=1);";
         }
     }
 


### PR DESCRIPTION
## Summary
- remove multi-column PRIMARY KEY DDL generation
- skip composite key physical test
- log progress

## Testing
- `dotnet test physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj` *(fails: KsqlContext initialization failed)*

------
https://chatgpt.com/codex/tasks/task_e_688175d684b88327aa77dfb69e99d2af