### PR TITLE
Implement Stream/Table interface restrictions

### DIFF
--- a/src/KsqlContext.cs
+++ b/src/KsqlContext.cs
@@ -600,6 +600,9 @@ internal class EventSetWithServices<T> : IEntitySet<T> where T : class
     /// </summary>
     public async Task<List<T>> ToListAsync(CancellationToken cancellationToken = default)
     {
+        if (_entityModel.GetExplicitStreamTableType() == StreamTableType.Stream)
+            throw new InvalidOperationException(
+                "ToListAsync() is not supported on a Stream source. Use ForEachAsync or subscribe for event consumption.");
         try
         {
             var cache = _ksqlContext.GetTableCache<T>();
@@ -636,6 +639,9 @@ internal class EventSetWithServices<T> : IEntitySet<T> where T : class
     /// </summary>
     public async Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default)
     {
+        if (_entityModel.GetExplicitStreamTableType() == StreamTableType.Table)
+            throw new InvalidOperationException(
+                "ForEachAsync() is not supported on a Table source. Use ToListAsync to obtain the full snapshot.");
         try
         {
             var consumerManager = _ksqlContext.GetConsumerManager();
@@ -652,6 +658,9 @@ internal class EventSetWithServices<T> : IEntitySet<T> where T : class
 
     public async Task ForEachAsync(Func<T, KafkaMessageContext, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default)
     {
+        if (_entityModel.GetExplicitStreamTableType() == StreamTableType.Table)
+            throw new InvalidOperationException(
+                "ForEachAsync() is not supported on a Table source. Use ToListAsync to obtain the full snapshot.");
         try
         {
             var consumerManager = _ksqlContext.GetConsumerManager();

--- a/tests/StreamTableInterfaceRestrictionTests.cs
+++ b/tests/StreamTableInterfaceRestrictionTests.cs
@@ -1,0 +1,85 @@
+using Kafka.Ksql.Linq;
+using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq.Configuration;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Modeling;
+using Kafka.Ksql.Linq.Query.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests;
+
+public class StreamTableInterfaceRestrictionTests
+{
+    private class TestContext : KsqlContext
+    {
+        public TestContext() : base(new KsqlDslOptions()) { }
+        protected override bool SkipSchemaRegistration => true;
+    }
+
+    private static EntityModel CreateTableModel()
+    {
+        var model = new EntityModel
+        {
+            EntityType = typeof(TestEntity),
+            TopicName = "t",
+            AllProperties = typeof(TestEntity).GetProperties(),
+            KeyProperties = new[] { typeof(TestEntity).GetProperty(nameof(TestEntity.Id))! }
+        };
+        model.SetStreamTableType(StreamTableType.Table);
+        return model;
+    }
+
+    private static EntityModel CreateStreamModel()
+    {
+        var model = new EntityModel
+        {
+            EntityType = typeof(TestEntity),
+            TopicName = "s",
+            AllProperties = typeof(TestEntity).GetProperties(),
+            KeyProperties = Array.Empty<PropertyInfo>()
+        };
+        model.SetStreamTableType(StreamTableType.Stream);
+        return model;
+    }
+
+    [Fact]
+    public async Task Table_ForEachAsync_Throws()
+    {
+        var ctx = new TestContext();
+        var set = new EventSetWithServices<TestEntity>(ctx, CreateTableModel());
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => set.ForEachAsync(_ => Task.CompletedTask));
+        Assert.Contains("ForEachAsync() is not supported", ex.Message);
+    }
+
+    [Fact]
+    public async Task Stream_ToListAsync_Throws()
+    {
+        var ctx = new TestContext();
+        var set = new EventSetWithServices<TestEntity>(ctx, CreateStreamModel());
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => set.ToListAsync());
+        Assert.Contains("ToListAsync() is not supported", ex.Message);
+    }
+
+    [Fact]
+    public async Task Table_ToListAsync_Allows()
+    {
+        var ctx = new TestContext();
+        var set = new EventSetWithServices<TestEntity>(ctx, CreateTableModel());
+        var list = await set.ToListAsync();
+        Assert.NotNull(list);
+    }
+
+    [Fact]
+    public async Task Stream_ForEachAsync_Allows()
+    {
+        var ctx = new TestContext();
+        var set = new EventSetWithServices<TestEntity>(ctx, CreateStreamModel());
+        await set.ForEachAsync(_ => Task.CompletedTask);
+    }
+}


### PR DESCRIPTION
## Summary
- restrict entity set retrieval APIs based on Stream/Table type
- add tests covering allowed and forbidden interface usage

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj -c Debug` *(fails: KafkaRestProxyValidationTests due to missing Kafka)*

------
https://chatgpt.com/codex/tasks/task_e_688181c6b84c8327bcc2af4ea65ba47e