### PR TITLE
Clarify Limit DSL as table-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,19 +170,16 @@ await context.Set<OrderCandle>()
 ```
 
 ### Set<T>().Limit(N)
-`Limit` を指定すると、Pull Query として N 件だけ取得した時点で処理が終了します。余分
-なレコードは内部で破棄されるため、`ForEachAsync` や `ToListAsync` でも N 件で完了しま
-す。
+`Limit` は Table 型 (`Set<T>`) の保持件数を制限する DSL です。`OnModelCreating` 内で宣言し、指定件数を超えた古いレコードは自動削除されます。Stream 型や実行時クエリでは使用できません。
 
 ```csharp
-var recent = await context.Set<Order>()
-    .Limit(100)
-    .ToListAsync();
+protected override void OnModelCreating(IModelBuilder modelBuilder)
+{
+    modelBuilder.Entity<Order>().Limit(100); // 最大100件のみ保持
+}
 ```
 
-`Limit` がバーエンティティに適用される場合、`WithWindow().Select<TBar>()`
-で `BarTime` プロパティへ代入した式が自動的に抽出され、並び替えに利用されます。
-追加の設定は不要です。
+`WithWindow().Select<TBar>()` を利用している場合、`BarTime` セレクターは自動的に抽出され、並び替えに使用されます。
 
 ### RemoveAsync とトムストーン
 `RemoveAsync` を呼び出すと、指定キーに対する値 `null` のメッセージ（トムストーン）がト

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -38,13 +38,13 @@
 | `.WithRetry(int)`              | リトライ設定                  | `EventSet<T>`                     | Stream        | ✅      |
 | `.StartErrorHandling()`        | エラーチェーン開始            | `IErrorHandlingChain<T>`          | Stream        | ✅      |
 | `.WithManualCommit()`          | 手動コミットモード切替        | `IEntityBuilder<T>`               | Subscription  | ✅      |
-| `.Limit(int)`                  | 取得件数を制限する Pull Query | `IEntitySet<T>`                  | Stream/Table  | ✅      |
+| `.Limit(int)`                  | **保持件数制限。Table型(Set<T>)でのみ利用可。OnModelCreatingで定義し、超過分は自動削除される。** | `IEntitySet<T>`                  | Table  | ✅      |
 
 - `ToList`/`ToListAsync` は Pull Query として実行されます【F:src/Query/Pipeline/DMLQueryGenerator.cs†L27-L34】。
 - `WithManualCommit()` を指定しない `ForEachAsync()` は自動コミット動作となります【F:docs/old/manual_commit.md†L1-L23】。
 - `OnError(ErrorAction.DLQ)` を指定すると DLQ トピックへ送信されます【F:docs/old/defaults.md†L52-L52】。
 - Messaging クラス自体は DLQ 送信処理を持たず、`ErrorOccurred`/`DeserializationError`/`ProduceError` などのイベントを通じて外部で DLQ 送信を行います。
-- `Set<T>().Limit(n)` を指定すると n 件取得後にストリームが終了します。残りのレコードは破棄されます。
+- `Set<T>().Limit(n)` は Table 型の保持件数を制限する DSL です。`OnModelCreating` 内で指定し、超過分のレコードは自動削除されます。Stream 型や実行時クエリでは利用できません。
 - バーエンティティでは `WithWindow().Select<TBar>()` で `BarTime` に代入した式が自動的に記録され、`Limit` の並び替えに使用されます。
 - `RemoveAsync(key)` は値 `null` のトムストーンを送り、KTable やキャッシュから該当キーのデータを削除します。
 - `.Window().BasedOn<TSchedule>` を用いる場合、バーは `[ScheduleRange]` 属性、または `openProp`/`closeProp` パラメータで示された `Open` ～ `Close` の範囲に含まれるデータのみで構成されます。日足生成で `Close` が 6:30 のときは、6:30 未満のデータが当日の終値として扱われます。

--- a/docs/changes/20250724_progress.md
+++ b/docs/changes/20250724_progress.md
@@ -13,3 +13,5 @@
 - extend schema registration wait time to improve reliability
 ## 2025-07-24 08:57 JST [assistant]
 - Removed unsupported multi-column PRIMARY KEY DDL from TestSchema and skipped CompositeKeyPocoTests.
+## 2025-07-24 12:02 JST [assistant]
+- Limit DSL clarified as Table-only in docs; added NotSupportedException when used on Stream.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -518,19 +518,16 @@ public class WindowedOrderSummary
 ## 9. 削除と件数制限の操作
 
 ### Set<T>().Limit(N)
-`Limit` を付与すると、KSQL の `LIMIT` 句を伴う Pull Query が生成されます。取得数が N
- 件に達した時点で処理が完了し、それ以降のレコードは自動的に破棄されます。
+`Limit` は Table 型 (`Set<T>`) の保持件数を制限する DSL です。`OnModelCreating` 内で宣言し、指定件数を超えた古いレコードは自動削除されます。Stream 型や実行時クエリでは使用できません。
 
 ```csharp
-var latest = await context.Set<Trade>()
-    .Limit(50)
-    .ToListAsync();
+protected override void OnModelCreating(IModelBuilder modelBuilder)
+{
+    modelBuilder.Entity<Trade>().Limit(50);
+}
 ```
 
-バー生成に `WithWindow().Select<TBar>()` を使用している場合、`BarTime` への
-代入式から自動的にタイムスタンプセレクターが取得され、`Limit` の並び替えに活用
-されます。
-
+バー生成に `WithWindow().Select<TBar>()` を使用している場合、`BarTime` への代入式から自動的にタイムスタンプセレクターが取得され、`Limit` の並び替えに活用されます。
 ### RemoveAsync でトムストーン送信
 `RemoveAsync` はキーを指定して値 `null` のメッセージ（トムストーン）をトピックへ送信し
 ます。これにより KTable やキャッシュに保持された同一キーのデータが削除されます。

--- a/src/EventSetLimitExtensions.cs
+++ b/src/EventSetLimitExtensions.cs
@@ -1,4 +1,5 @@
 using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Query.Abstractions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -23,6 +24,8 @@ public static class EventSetLimitExtensions
 
         var items = await entitySet.ToListAsync(cancellationToken);
         var model = entitySet.GetEntityModel();
+        if (model.GetExplicitStreamTableType() != StreamTableType.Table)
+            throw new NotSupportedException("Limit is only supported for Table entities.");
         if (model.BarTimeSelector == null)
             throw new InvalidOperationException($"Entity {typeof(T).Name} is missing bar time selector configuration.");
 


### PR DESCRIPTION
## Summary
- clarify `.Limit()` usage as Table-only in docs
- show OnModelCreating example in README and getting-started
- enforce table check in `EventSetLimitExtensions`
- log documentation update in progress log

## Testing
- `dotnet test Kafka.Ksql.Linq.sln -c Release` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68819e375b7083279ddd291e6013978e