### PR TITLE
DLQ stream via Set<T>

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -43,6 +43,7 @@
 - `ToList`/`ToListAsync` は Pull Query として実行されます【F:src/Query/Pipeline/DMLQueryGenerator.cs†L27-L34】。
 - `WithManualCommit()` を指定しない `ForEachAsync()` は自動コミット動作となります【F:docs/old/manual_commit.md†L1-L23】。
 - `OnError(ErrorAction.DLQ)` を指定すると DLQ トピックへ送信されます【F:docs/old/defaults.md†L52-L52】。
+- `ctx.Set<DlqEnvelope>()` を指定すると DLQ ストリームを取得できます。DLQ は無限ログのため `Take()` や `ToListAsync()` などの一括取得 API は利用できず、`ForEachAsync()` のみサポートします。また DLQ ストリームで `.OnError(ErrorAction.DLQ)` を指定すると無限ループになるため禁止されています。
 - Messaging クラス自体は DLQ 送信処理を持たず、`ErrorOccurred`/`DeserializationError`/`ProduceError` などのイベントを通じて外部で DLQ 送信を行います。
 - `Set<T>().Limit(n)` を指定すると n 件取得後にストリームが終了します。残りのレコードは破棄されます。
 - バーエンティティでは `WithWindow().Select<TBar>()` で `BarTime` に代入した式が自動的に記録され、`Limit` の並び替えに使用されます。

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -340,6 +340,8 @@ await context.Orders
 
 このように、明示的なエラーハンドリング設計が求められます。
 
+DLQ の内容を確認する場合は `ctx.Set<DlqEnvelope>()` を用います。DLQ は履歴ストリームであり `Take()` や `ToListAsync()` などの件数指定取得はできません。すべて `ForEachAsync()` で逐次処理してください。さらに DLQ ストリームでは `.OnError(ErrorAction.DLQ)` は無限ループ防止のため禁止されています。
+
 ### commitの制御
 Kafkaのコンシューム操作において、メッセージのオフセットコミットは非常に重要です。
 

--- a/src/EventSet.cs
+++ b/src/EventSet.cs
@@ -95,6 +95,9 @@ public abstract class EventSet<T> : IEntitySet<T> where T : class
 
     public virtual async Task<List<T>> ToListAsync(CancellationToken cancellationToken = default)
     {
+        if (_entityModel.EntityType == typeof(Core.Models.DlqEnvelope))
+            throw new InvalidOperationException("DLQは無限列挙/履歴列であり、バッチ取得・件数指定取得は現状未対応です");
+
         if (_entityModel.GetExplicitStreamTableType() == StreamTableType.Stream)
             throw new InvalidOperationException("ToListAsync() is not supported on a Stream source. Use ForEachAsync or subscribe for event consumption.");
 

--- a/src/EventSetErrorHandlingExtensions.cs
+++ b/src/EventSetErrorHandlingExtensions.cs
@@ -12,6 +12,9 @@ public static class EventSetErrorHandlingExtensions
 
     public static EventSet<T> OnError<T>(this EventSet<T> eventSet, ErrorAction errorAction) where T : class
     {
+        if (typeof(T) == typeof(Core.Models.DlqEnvelope) && errorAction == ErrorAction.DLQ)
+            throw new InvalidOperationException("DLQストリームでOnError(DLQ)は利用できません（無限ループ防止のため）");
+
         var policy = new ErrorHandlingPolicy
         {
             Action = errorAction

--- a/tests/DlqStreamRestrictionsTests.cs
+++ b/tests/DlqStreamRestrictionsTests.cs
@@ -1,0 +1,36 @@
+using Kafka.Ksql.Linq;
+using Kafka.Ksql.Linq.Configuration;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Models;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests;
+
+public class DlqStreamRestrictionsTests
+{
+    private class TestContext : KsqlContext
+    {
+        public TestContext() : base(new KsqlDslOptions()) { }
+        protected override bool SkipSchemaRegistration => true;
+    }
+
+    [Fact]
+    public async Task DlqStream_ForEachAsync_Allows()
+    {
+        var ctx = new TestContext();
+        var stream = ctx.Set<DlqEnvelope>();
+        await stream.ForEachAsync(_ => Task.CompletedTask);
+    }
+
+    [Fact]
+    public async Task DlqStream_ToListAsync_Throws()
+    {
+        var ctx = new TestContext();
+        var stream = ctx.Set<DlqEnvelope>();
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => stream.ToListAsync());
+        Assert.Contains("DLQ", ex.Message);
+    }
+
+}


### PR DESCRIPTION
## Summary
- remove `Stream<T>` from IKsqlContext and use `Set<T>` for DLQ stream access
- add DLQ model initialization and override Set to return the DLQ stream
- clarify documentation to use `ctx.Set<DlqEnvelope>()`
- enforce DLQ batch retrieval restriction before stream check
- update DLQ unit test

## Testing
- `dotnet test --filter "Category!=Integration" -v minimal` *(fails: unable to connect to Kafka)*

------
https://chatgpt.com/codex/tasks/task_e_68819c8be94083279d6504aadba5607d