### PR TITLE
Clarify infra test tracking

### DIFF
--- a/docs/changes/20250731_progress.md
+++ b/docs/changes/20250731_progress.md
@@ -135,3 +135,9 @@
 - added integration tests for DLQ, ksqlDB outage, advanced data types, dummy flag skipping, and invalid KSQL
 ## 2025-07-24 08:24 JST [assistant]
 - improved schema setup retries and validation
+## 2025-07-24 11:45 JST [codex]
+- updated connectivity README to clarify single-method test pattern and PriorityOrderer usage
+- reviewed infrastructure tests per PM instruction; all sequences run in isolated methods or enforce order
+## 2025-07-24 12:06 JST [codex]
+- classified `DummyMessages_EnableQueries` and `CreateAllObjectsByOnModelCreating` as infrastructure tests
+- confirmed both encapsulate setup and cleanup within single `[Fact]` methods

--- a/physicalTests/Connectivity/README.md
+++ b/physicalTests/Connectivity/README.md
@@ -2,7 +2,14 @@
 
 These tests validate that each service in the docker environment is reachable.
 Run them sequentially so any failure clearly indicates which component is
-unavailable.
+unavailable. To keep environment state consistent, each test class encapsulates
+the complete setup–verification–cleanup sequence in a single `[Fact]` method.
+If multiple methods are required, apply `PriorityOrderer` with `[TestPriority]`
+attributes to enforce the execution order (see `PriorityOrderer.cs`).
+
+Tests such as `DummyMessages_EnableQueries` and `CreateAllObjectsByOnModelCreating`
+also follow this infrastructure pattern even though they live outside this
+folder.
 
 ## Recommended order and verification points
 


### PR DESCRIPTION
## Summary
- document PriorityOrderer location and example infra tests in Connectivity README
- log additional progress about classifying DummyMessages_EnableQueries and CreateAllObjectsByOnModelCreating as infrastructure tests

## Testing
- `dotnet test physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj --filter Category=Integration --no-build` *(failed: attempted to run but cancelled due to missing Kafka connectivity)*

------
https://chatgpt.com/codex/tasks/task_e_688199b3486083279aeaac67851264b9