### PR TITLE
Use WaitForEntityReadyAsync in integration tests

### DIFF
--- a/docs/changes/20250724_progress.md
+++ b/docs/changes/20250724_progress.md
@@ -18,3 +18,7 @@
 - Added WaitForEntityReadyAsync API and sample usage
 ## 2025-07-24 12:02 JST [assistant]
 - Limit DSL clarified as Table-only in docs; added NotSupportedException when used on Stream.
+## 2025-07-24 13:15 JST [assistant]
+- Updated physical tests to use WaitForEntityReadyAsync for schema readiness
+- Removed manual Task.Delay calls in DummyFlagSchemaRecognitionTests and DynamicKsqlGenerationTests
+- Setup now waits for composite key order table using the new API

--- a/physicalTests/KsqlSyntax/DynamicKsqlGenerationTests.cs
+++ b/physicalTests/KsqlSyntax/DynamicKsqlGenerationTests.cs
@@ -373,7 +373,13 @@ public class DynamicKsqlGenerationTests
         await ctx.Set<NullableOrder>().AddAsync(new NullableOrder { CustomerId = 1, Region = "east", Amount = 10d });
         await ctx.Set<NullableKeyOrder>().AddAsync(new NullableKeyOrder { CustomerId = 1, Amount = 10d });
 
-        await Task.Delay(500);
+        var timeout = TimeSpan.FromSeconds(5);
+        await ctx.WaitForEntityReadyAsync<OrderValue>(timeout);
+        await ctx.WaitForEntityReadyAsync<Customer>(timeout);
+        await ctx.WaitForEntityReadyAsync<EventLog>(timeout);
+        await ctx.WaitForEntityReadyAsync<NullableOrder>(timeout);
+        await ctx.WaitForEntityReadyAsync<NullableKeyOrder>(timeout);
+
         await ctx.DisposeAsync();
     }
 }

--- a/physicalTests/OssSamples/DummyFlagSchemaRecognitionTests.cs
+++ b/physicalTests/OssSamples/DummyFlagSchemaRecognitionTests.cs
@@ -92,7 +92,13 @@ public class DummyFlagSchemaRecognitionTests
         await ctx.Set<NullableOrder>().AddAsync(new NullableOrder { CustomerId = 1, Region = "east", Amount = 10d }, headers);
         await ctx.Set<NullableKeyOrder>().AddAsync(new NullableKeyOrder { CustomerId = 1, Amount = 10d }, headers);
 
-        await Task.Delay(500);
+        var timeout = TimeSpan.FromSeconds(5);
+        await ctx.WaitForEntityReadyAsync<OrderValue>(timeout);
+        await ctx.WaitForEntityReadyAsync<Customer>(timeout);
+        await ctx.WaitForEntityReadyAsync<EventLog>(timeout);
+        await ctx.WaitForEntityReadyAsync<NullableOrder>(timeout);
+        await ctx.WaitForEntityReadyAsync<NullableKeyOrder>(timeout);
+
         await ctx.DisposeAsync();
     }
 
@@ -115,7 +121,6 @@ public class DummyFlagSchemaRecognitionTests
         }
 
         await ProduceDummyRecordsAsync();
-        await Task.Delay(2000);
 
         var queries = new[]
         {

--- a/physicalTests/TestEnvironment.cs
+++ b/physicalTests/TestEnvironment.cs
@@ -125,7 +125,8 @@ internal static class TestEnvironment
                 ProductId = 0,
                 Quantity = 0
             });
-            await Task.Delay(500);
+
+            await orderCtx.WaitForEntityReadyAsync<Order>(TimeSpan.FromSeconds(5));
         }
 
         await ValidateSchemaRegistrationAsync();


### PR DESCRIPTION
## Summary
- update DummyFlagSchemaRecognitionTests to wait for entity readiness
- update DynamicKsqlGenerationTests to wait for entity readiness
- ensure TestEnvironment waits for composite key schema registration
- log progress

## Testing
- `dotnet build physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj --no-restore -v minimal`
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --no-build --no-restore -v minimal` *(fails: Key serialization error)*

------
https://chatgpt.com/codex/tasks/task_e_6881b1d27af48327807a02ce3e3502c8