### PR TITLE
Fix dummy header test expectations

### DIFF
--- a/docs/changes/20250724_progress.md
+++ b/docs/changes/20250724_progress.md
@@ -26,3 +26,5 @@
 - Updated physical tests to use WaitForEntityReadyAsync for schema readiness
 - Removed manual Task.Delay calls in DummyFlagSchemaRecognitionTests and DynamicKsqlGenerationTests
 - Setup now waits for composite key order table using the new API
+## 2025-07-24 15:23 JST [assistant]
+- updated dummy flag tests to verify automatic filtering

--- a/physicalTests/OssSamples/DummyFlagMessageTests.cs
+++ b/physicalTests/OssSamples/DummyFlagMessageTests.cs
@@ -66,12 +66,11 @@ public class DummyFlagMessageTests
             Count = 1
         }, headers);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => ctx.Set<OrderValue>().ToListAsync());
+        var list = await ctx.Set<OrderValue>().ToListAsync();
+        Assert.Empty(list);
 
         var consumed = new List<OrderValue>();
         await ctx.Set<OrderValue>().ForEachAsync(o => { consumed.Add(o); return Task.CompletedTask; }, TimeSpan.FromSeconds(1));
-        Assert.Single(consumed);
-
-        await ctx.DisposeAsync();
+        Assert.Empty(consumed);
     }
 }

--- a/tests/DummyHeaderIgnoreTests.cs
+++ b/tests/DummyHeaderIgnoreTests.cs
@@ -63,13 +63,12 @@ public class DummyHeaderIgnoreTests
         var set = new DummyHeaderSet(items, CreateModel());
         var processed = new List<int>();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            set.ForEachAsync((msg, ctx) =>
-            {
-                if (ctx.Headers.TryGetValue("is_dummy", out var d) && d is bool b && b)
-                    return Task.CompletedTask;
-                processed.Add(msg.Id);
-                return Task.CompletedTask;
-            }));
+        await set.ForEachAsync((msg, ctx) =>
+        {
+            processed.Add(msg.Id);
+            return Task.CompletedTask;
+        });
+
+        Assert.Equal(new[] { 1 }, processed);
     }
 }

--- a/tests/EventSetKafkaContextTests.cs
+++ b/tests/EventSetKafkaContextTests.cs
@@ -60,13 +60,12 @@ public class EventSetKafkaContextTests
         var set = new HeaderSet(items, CreateModel());
         var processed = new List<int>();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            set.ForEachAsync((msg, ctx) =>
-            {
-                if (ctx.Headers.TryGetValue("is_dummy", out var d) && d is bool b && b)
-                    return Task.CompletedTask;
-                processed.Add(msg.Id);
-                return Task.CompletedTask;
-            }));
+        await set.ForEachAsync((msg, ctx) =>
+        {
+            processed.Add(msg.Id);
+            return Task.CompletedTask;
+        });
+
+        Assert.Equal(new[] { 1 }, processed);
     }
 }


### PR DESCRIPTION
## Summary
- update unit tests to expect `is_dummy` messages are ignored
- adjust integration test for filtered dummy messages
- log progress

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj -v minimal` *(fails: Limit_RemovesOldItemsAndReturnsNewest, ForEachAsync_DummyHeader_MessageIgnored, ForEachAsync_WithContext_HeaderCanBeRead, KafkaRestProxyValidationTests.Appsettings_ShouldMapCorrectly_AndSendKafkaMessage)*

------
https://chatgpt.com/codex/tasks/task_e_6881d0b49c4c8327b46dce9d94119b31