### PR TITLE
Handle ResetAsync failures gracefully

### DIFF
--- a/physicalTests/OssSamples/AdvancedDataTypeTests.cs
+++ b/physicalTests/OssSamples/AdvancedDataTypeTests.cs
@@ -44,7 +44,15 @@ public class AdvancedDataTypeTests
         if (!KsqlDbAvailability.IsAvailable())
             throw new SkipException(KsqlDbAvailability.SkipReason);
 
-        await TestEnvironment.ResetAsync();
+        try
+        {
+            await TestEnvironment.ResetAsync();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[Warning] ResetAsync failed: {ex}");
+            throw new SkipException($"Test setup failed in ResetAsync: {ex.Message}");
+        }
 
         var options = new KsqlDslOptions
         {


### PR DESCRIPTION
## Summary
- don't break integration test when TestEnvironment.ResetAsync throws

## Testing
- `dotnet test physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj` *(fails: Kafka connectivity)*
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj` *(fails: some unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_6881d3ab6518832798a333e6f6343123