### PR TITLE
Fix context mismatch test

### DIFF
--- a/physicalTests/OssSamples/SchemaNameCaseSensitivityTests.cs
+++ b/physicalTests/OssSamples/SchemaNameCaseSensitivityTests.cs
@@ -92,15 +92,16 @@ public class SchemaNameCaseSensitivityTests
         await Assert.ThrowsAsync<InvalidOperationException>(() => ctx.Set<OrderCorrectCase>().ToListAsync());
 
 
-        await using var wrongCtx = new WrongCaseContext(options);
-
-        await Assert.ThrowsAsync<SchemaRegistryException>(() =>
-            wrongCtx.Set<OrderWrongCase>().AddAsync(new OrderWrongCase
+        await Assert.ThrowsAsync<SchemaRegistryException>(async () =>
+        {
+            await using var wrongCtx = new WrongCaseContext(options); // ここで例外を期待
+            await wrongCtx.Set<OrderWrongCase>().AddAsync(new OrderWrongCase
             {
                 CustomerId = 1,
                 Id = 1,
                 region = "west",
                 Amount = 5d
-            }, headers));
+            }, headers);
+        });
     }
 }


### PR DESCRIPTION
## Summary
- update the schema mismatch test to fail when `WrongCaseContext` is created

## Testing
- `dotnet test physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj --filter Category=Integration` *(fails: `$XunitDynamicSkip$Skipped in CI due to missing ksqlDB instance or schema setup failure`)*

------
https://chatgpt.com/codex/tasks/task_e_6881dbc0b8908327b5ac20b4ede1e85d