### PR TITLE
Improve KsqlContext error reporting

### DIFF
--- a/src/KsqlContext.cs
+++ b/src/KsqlContext.cs
@@ -101,8 +101,18 @@ public abstract class KsqlContext : IKsqlContext
         }
         catch (Exception ex)
         {
+            var hint = string.Empty;
+            if (ex is HttpRequestException || ex.InnerException is HttpRequestException)
+            {
+                hint = " Could not connect to ksqlDB endpoint.";
+            }
+            else if (ex is KafkaException || ex.InnerException is KafkaException)
+            {
+                hint = " Cannot connect to Kafka cluster.";
+            }
+
             throw new InvalidOperationException(
-                "FATAL: KsqlContext initialization failed. Application cannot continue without Kafka connectivity.", ex);
+                $"FATAL: KsqlContext initialization failed.{hint} See inner exception for details. {ex.Message}", ex);
         }
     }
 
@@ -148,8 +158,18 @@ public abstract class KsqlContext : IKsqlContext
         }
         catch (Exception ex)
         {
+            var hint = string.Empty;
+            if (ex is HttpRequestException || ex.InnerException is HttpRequestException)
+            {
+                hint = " Could not connect to ksqlDB endpoint.";
+            }
+            else if (ex is KafkaException || ex.InnerException is KafkaException)
+            {
+                hint = " Cannot connect to Kafka cluster.";
+            }
+
             throw new InvalidOperationException(
-                "FATAL: KsqlContext initialization failed. Application cannot continue without Kafka connectivity.", ex);
+                $"FATAL: KsqlContext initialization failed.{hint} See inner exception for details. {ex.Message}", ex);
         }
     }
 


### PR DESCRIPTION
## Summary
- clarify initialization errors in `KsqlContext`
- detect when the failure is from ksqlDB or Kafka connectivity

## Testing
- `dotnet build src/Kafka.Ksql.Linq.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj -v m` *(fails: Property or indexer 'EntityModel.StreamTableType' cannot be assigned)*

------
https://chatgpt.com/codex/tasks/task_e_6881e2131ab48327bcb79e46bb28688b