### PR TITLE
Direct HTTP validation for KSQL syntax

### DIFF
--- a/docs/changes/20250731_progress.md
+++ b/docs/changes/20250731_progress.md
@@ -135,3 +135,5 @@
 - added integration tests for DLQ, ksqlDB outage, advanced data types, dummy flag skipping, and invalid KSQL
 ## 2025-07-24 08:24 JST [assistant]
 - improved schema setup retries and validation
+## 2025-07-24 16:55 JST [sion]
+- updated GeneratedQuery_IsValidInKsqlDb to validate via raw HTTP client instead of AdminContext


### PR DESCRIPTION
## Summary
- run GeneratedQuery_IsValidInKsqlDb by calling ksqlDB REST API directly
- log the update in progress notes

## Testing
- `dotnet test physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj --filter Category=Integration -c Release` *(fails: KsqlContext initialization failed)*

------
https://chatgpt.com/codex/tasks/task_e_6881e5d7aca88327ad7c3a8c5b171fac