### PR TITLE
Add schema materialization utility

### DIFF
--- a/src/Application/DummyObjectFactory.cs
+++ b/src/Application/DummyObjectFactory.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Reflection;
+
+namespace Kafka.Ksql.Linq.Application;
+
+internal static class DummyObjectFactory
+{
+    public static T CreateDummy<T>() where T : class, new()
+    {
+        var obj = new T();
+        foreach (var prop in typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (!prop.CanWrite) continue;
+            var type = Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType;
+            object? value = type.IsValueType ? Activator.CreateInstance(type) : "dummy";
+            if (type == typeof(string)) value = "dummy";
+            else if (type == typeof(bool)) value = true;
+            else if (type == typeof(Guid)) value = Guid.NewGuid();
+            else if (type == typeof(DateTime)) value = DateTime.UtcNow;
+            else if (type == typeof(DateTimeOffset)) value = DateTimeOffset.UtcNow;
+            else if (type.IsEnum) value = Enum.GetValues(type).GetValue(0);
+            try { prop.SetValue(obj, value); } catch { }
+        }
+        return obj;
+    }
+}

--- a/src/Application/MaterializationExtensions.cs
+++ b/src/Application/MaterializationExtensions.cs
@@ -1,0 +1,28 @@
+using Kafka.Ksql.Linq.Core.Models;
+using Kafka.Ksql.Linq.Messaging.Internal;
+using Kafka.Ksql.Linq.SchemaRegistryTools;
+using System.Collections.Generic;
+using System;
+using System.Threading.Tasks;
+
+namespace Kafka.Ksql.Linq.Application;
+
+public static class MaterializationExtensions
+{
+    public static async Task EnsureMaterializedIfSchemaIsNewAsync<T>(this KsqlContext context) where T : class, new()
+    {
+        if (context == null) throw new ArgumentNullException(nameof(context));
+        var client = context.GetSchemaRegistryClient();
+        var model = context.GetEntityModels()[typeof(T)];
+        var ns = typeof(T).Namespace?.ToLowerInvariant() ?? string.Empty;
+        var name = typeof(T).Name.ToLowerInvariant();
+        var subject = $"{ns}.{name}-value";
+        var schema = DynamicSchemaGenerator.GetSchemaJson<T>();
+        var result = await client.RegisterSchemaIfNewAsync(subject, schema);
+        if (result.WasCreated)
+        {
+            var dummy = DummyObjectFactory.CreateDummy<T>();
+            await context.Set<T>().AddAsync(dummy, new Dictionary<string, string> { ["is_dummy"] = "true" });
+        }
+    }
+}

--- a/src/SchemaRegistryTools/SchemaRegistryExtensions.cs
+++ b/src/SchemaRegistryTools/SchemaRegistryExtensions.cs
@@ -1,0 +1,39 @@
+using Confluent.SchemaRegistry;
+using System;
+using System.Threading.Tasks;
+
+namespace Kafka.Ksql.Linq.SchemaRegistryTools;
+
+public readonly record struct SchemaRegistrationResult(int SchemaId, bool WasCreated);
+
+public static class SchemaRegistryExtensions
+{
+    public static async Task<SchemaRegistrationResult> RegisterSchemaIfNewAsync(this ISchemaRegistryClient client, string subject, string schema)
+    {
+        if (client == null) throw new ArgumentNullException(nameof(client));
+        if (subject == null) throw new ArgumentNullException(nameof(subject));
+        if (schema == null) throw new ArgumentNullException(nameof(schema));
+
+        bool isNew = false;
+        try
+        {
+            var latest = await client.GetLatestSchemaAsync(subject);
+            if (latest.SchemaString != schema)
+            {
+                isNew = true;
+            }
+            else
+            {
+                return new SchemaRegistrationResult(latest.Id, false);
+            }
+        }
+        catch (SchemaRegistryException ex) when (ex.ErrorCode == 404 || ex.ErrorCode == 40401)
+        {
+            isNew = true;
+        }
+
+        var sch = new Schema(schema, SchemaType.Avro);
+        var id = await client.RegisterSchemaAsync(subject, sch, false);
+        return new SchemaRegistrationResult(id, isNew);
+    }
+}

--- a/tests/Application/MaterializationExtensionsTests.cs
+++ b/tests/Application/MaterializationExtensionsTests.cs
@@ -1,0 +1,66 @@
+using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq.Configuration;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Configuration;
+using Kafka.Ksql.Linq.Core.Modeling;
+using Kafka.Ksql.Linq.Tests;
+using Confluent.SchemaRegistry;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+using System;
+
+namespace Kafka.Ksql.Linq.Tests.Application;
+
+public class MaterializationExtensionsTests
+{
+    public class Order
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private class TestContext : KsqlContext
+    {
+        public StubEntitySet<Order>? StubSet;
+        private readonly ISchemaRegistryClient _client;
+        public TestContext(ISchemaRegistryClient client) : base(new KsqlDslOptions
+        {
+            Common = new CommonSection { BootstrapServers = "b" },
+            SchemaRegistry = new SchemaRegistrySection { Url = "dummy" }
+        })
+        {
+            _client = client;
+            var field = typeof(KsqlContext).GetField("_schemaRegistryClient", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            field.SetValue(this, new Lazy<ISchemaRegistryClient>(() => _client));
+        }
+        protected override bool SkipSchemaRegistration => true;
+        protected override void OnModelCreating(IModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Order>().WithTopic("orders");
+        }
+        protected override IEntitySet<T> CreateEntitySet<T>(EntityModel model)
+        {
+            if (typeof(T) == typeof(Order))
+            {
+                StubSet = new StubEntitySet<Order>();
+                return (IEntitySet<T>)StubSet;
+            }
+            return base.CreateEntitySet<T>(model);
+        }
+    }
+
+    [Fact]
+    public async Task SendsDummyOnlyOnFirstRegistration()
+    {
+        var client = new FakeSchemaRegistryClient();
+        await using var ctx = new TestContext(client);
+        await ctx.EnsureMaterializedIfSchemaIsNewAsync<Order>();
+        Assert.NotNull(ctx.StubSet);
+        Assert.Single(ctx.StubSet!.Added);
+        Assert.Equal("true", ctx.StubSet!.Added[0].Headers?["is_dummy"]);
+
+        await ctx.EnsureMaterializedIfSchemaIsNewAsync<Order>();
+        Assert.Single(ctx.StubSet!.Added);
+    }
+}

--- a/tests/FakeSchemaRegistryClient.cs
+++ b/tests/FakeSchemaRegistryClient.cs
@@ -1,0 +1,69 @@
+using Confluent.SchemaRegistry;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Kafka.Ksql.Linq.Tests;
+
+internal class FakeSchemaRegistryClient : ISchemaRegistryClient
+{
+    private readonly Dictionary<string, List<(string Schema, int Id)>> _store = new();
+    private int _nextId = 1;
+
+    public IEnumerable<KeyValuePair<string, string>> Config => Array.Empty<KeyValuePair<string, string>>();
+    public IAuthenticationHeaderValueProvider? AuthHeaderProvider => null;
+    public System.Net.IWebProxy? Proxy => null;
+    public int MaxCachedSchemas => 1000;
+
+    public Task<int> RegisterSchemaAsync(string subject, string schema, bool normalize)
+    {
+        if (!_store.TryGetValue(subject, out var list))
+        {
+            list = new List<(string, int)>();
+            _store[subject] = list;
+        }
+        var existing = list.Find(p => p.Schema == schema);
+        if (existing.Schema != null)
+            return Task.FromResult(existing.Id);
+        var id = _nextId++;
+        list.Add((schema, id));
+        return Task.FromResult(id);
+    }
+
+    public Task<int> RegisterSchemaAsync(string subject, Schema schema, bool normalize) => RegisterSchemaAsync(subject, schema.SchemaString, normalize);
+    public Task<int> RegisterSchemaAsync(string subject, string schema) => RegisterSchemaAsync(subject, schema, false);
+    public Task<int> RegisterSchemaAsync(string subject, Schema schema) => RegisterSchemaAsync(subject, schema.SchemaString, false);
+
+    public Task<RegisteredSchema> GetLatestSchemaAsync(string subject)
+    {
+        if (!_store.TryGetValue(subject, out var list) || list.Count == 0)
+            throw new SchemaRegistryException("Subject not found", 40401);
+        var (schema, id) = list[^1];
+        var rs = new RegisteredSchema(subject, list.Count, id, schema, SchemaType.Avro, new List<SchemaReference>());
+        return Task.FromResult(rs);
+    }
+
+    // Unused members
+    public Task<RegisteredSchema> RegisterSchemaWithResponseAsync(string subject, Schema schema, bool normalize) => throw new NotImplementedException();
+    public Task<int> GetSchemaIdAsync(string subject, string schema, bool normalize) => throw new NotImplementedException();
+    public Task<int> GetSchemaIdAsync(string subject, Schema schema, bool normalize) => throw new NotImplementedException();
+    public Task<Schema> GetSchemaAsync(int id, string format) => throw new NotImplementedException();
+    public Task<Schema> GetSchemaBySubjectAndIdAsync(string subject, int id, string format) => throw new NotImplementedException();
+    public Task<Schema> GetSchemaByGuidAsync(string id, string format) => throw new NotImplementedException();
+    public Task<RegisteredSchema> LookupSchemaAsync(string subject, Schema schema, bool normalize, bool lookupDeletedSchema) => throw new NotImplementedException();
+    public Task<RegisteredSchema> GetRegisteredSchemaAsync(string subject, int version, bool lookupDeletedSchema) => throw new NotImplementedException();
+    public Task<string> GetSchemaAsync(string subject, int version) => throw new NotImplementedException();
+    public Task<RegisteredSchema> GetLatestWithMetadataAsync(string subject, IDictionary<string, string> headers, bool ignoreDeletedSchemas) => throw new NotImplementedException();
+    public Task<List<string>> GetAllSubjectsAsync() => throw new NotImplementedException();
+    public Task<List<int>> GetSubjectVersionsAsync(string subject) => throw new NotImplementedException();
+    public Task<bool> IsCompatibleAsync(string subject, string schema) => throw new NotImplementedException();
+    public Task<bool> IsCompatibleAsync(string subject, Schema schema) => throw new NotImplementedException();
+    public string ConstructKeySubjectName(string subject, string topic) => throw new NotImplementedException();
+    public string ConstructValueSubjectName(string subject, string topic) => throw new NotImplementedException();
+    public Task<Compatibility> GetCompatibilityAsync(string subject) => throw new NotImplementedException();
+    public Task<Compatibility> UpdateCompatibilityAsync(Compatibility compatibility, string subject) => throw new NotImplementedException();
+    public void ClearLatestCaches() { }
+    public void ClearCaches() { }
+
+    public void Dispose() { }
+}

--- a/tests/StubEntitySet.cs
+++ b/tests/StubEntitySet.cs
@@ -1,0 +1,26 @@
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Models;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kafka.Ksql.Linq.Tests;
+
+internal class StubEntitySet<T> : IEntitySet<T> where T : class
+{
+    public List<(T Entity, Dictionary<string,string>? Headers)> Added { get; } = new();
+    public Task AddAsync(T entity, Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default)
+    {
+        Added.Add((entity, headers));
+        return Task.CompletedTask;
+    }
+    public Task RemoveAsync(T entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<T>());
+    public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    public Task ForEachAsync(Func<T, KafkaMessageContext, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    public string GetTopicName() => "stub";
+    public EntityModel GetEntityModel() => new EntityModel { EntityType = typeof(T) };
+    public IKsqlContext GetContext() => throw new NotImplementedException();
+    public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+}


### PR DESCRIPTION
## Summary
- add `RegisterSchemaIfNewAsync` to detect new schema registration
- add utility to send a dummy message when schemas are newly registered
- provide simple dummy object factory for tests
- add unit tests with fake schema registry

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --filter "Category!=Integration"` *(fails: cannot build tests)*

------
https://chatgpt.com/codex/tasks/task_e_6881eab7378c8327b4dc36e39a8caa50