### PR TITLE
Remove schema registration from producers

### DIFF
--- a/docs/changes/20250722_progress.md
+++ b/docs/changes/20250722_progress.md
@@ -32,3 +32,5 @@
 - Implemented automatic generation of empty windows in WindowProcessor
 - Added unit test to verify empty window generation
 
+## 2025-07-24 18:32 JST [assistant]
+- Messaging層の自動スキーマ登録を削除

--- a/docs/changes/20250722_progress.md
+++ b/docs/changes/20250722_progress.md
@@ -32,5 +32,3 @@
 - Implemented automatic generation of empty windows in WindowProcessor
 - Added unit test to verify empty window generation
 
-## 2025-07-24 18:32 JST [assistant]
-- Messaging層の自動スキーマ登録を削除

--- a/docs/changes/20250724_progress.md
+++ b/docs/changes/20250724_progress.md
@@ -32,3 +32,6 @@
 
 ## 2025-07-24 15:32 JST [assistant]\n- rewrote CreateAllObjectsByOnModelCreating test to use OnModelCreating context and SHOW statements\n- added DSL-based verification of streams and tables
 
+## 2025-07-24 18:39 JST [assistant]
+- Messaging層の自動スキーマ登録を削除
+

--- a/physicalTests/Connectivity/KafkaServiceDownTests.cs
+++ b/physicalTests/Connectivity/KafkaServiceDownTests.cs
@@ -46,7 +46,7 @@ public class KafkaServiceDownTests
             await TestEnvironment.ResetAsync();
 
         }
-        catch (Exception ex1)
+        catch (Exception)
         {
 
         }
@@ -77,7 +77,7 @@ public class KafkaServiceDownTests
             await TestEnvironment.ResetAsync();
 
         }
-        catch (Exception ex1)
+        catch (Exception)
         {
 
         }

--- a/physicalTests/Connectivity/KsqlDbServiceDownTests.cs
+++ b/physicalTests/Connectivity/KsqlDbServiceDownTests.cs
@@ -24,7 +24,7 @@ public class KsqlDbServiceDownTests
             await TestEnvironment.ResetAsync();
 
         }
-        catch (Exception ex)
+        catch (Exception)
         {
         }
         await DockerHelper.StopServiceAsync("ksqldb-server");

--- a/physicalTests/Connectivity/SchemaRegistryResetTests.cs
+++ b/physicalTests/Connectivity/SchemaRegistryResetTests.cs
@@ -69,7 +69,7 @@ public class SchemaRegistryResetTests
             await TestEnvironment.ResetAsync();
 
         }
-        catch (Exception ex)
+        catch (Exception)
         {
 
         }
@@ -98,7 +98,7 @@ public class SchemaRegistryResetTests
             await TestEnvironment.ResetAsync();
 
         }
-        catch (Exception ex)
+        catch (Exception)
         {
 
         }
@@ -121,7 +121,7 @@ public class SchemaRegistryResetTests
             await TestEnvironment.ResetAsync();
 
         }
-        catch (Exception ex)
+        catch (Exception)
         {
 
         }

--- a/physicalTests/EventSetExtensions.cs
+++ b/physicalTests/EventSetExtensions.cs
@@ -3,6 +3,8 @@ using Kafka.Ksql.Linq.Application;
 using Kafka.Ksql.Linq.Messaging.Producers;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using System;
+
+#nullable enable
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;

--- a/physicalTests/KsqlSyntax/DynamicKsqlGenerationTests.cs
+++ b/physicalTests/KsqlSyntax/DynamicKsqlGenerationTests.cs
@@ -289,7 +289,7 @@ public class DynamicKsqlGenerationTests
             await TestEnvironment.ResetAsync();
 
         }
-        catch (Exception ex)
+        catch (Exception)
         {
         }
 

--- a/physicalTests/KsqlSyntax/InvalidQueryTests.cs
+++ b/physicalTests/KsqlSyntax/InvalidQueryTests.cs
@@ -22,7 +22,7 @@ public class InvalidQueryTests
             await TestEnvironment.ResetAsync();
 
         }
-        catch (System.Exception ex)
+        catch (System.Exception)
         {
 
         }

--- a/physicalTests/LinqHelpers/KsqlTestLinqExtensions.cs
+++ b/physicalTests/LinqHelpers/KsqlTestLinqExtensions.cs
@@ -6,6 +6,8 @@ using System.Linq.Expressions;
 using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Query.Pipeline;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests.Integration;
 
 internal static class KsqlTestLinqExtensions

--- a/physicalTests/OssSamples/DummyFlagSchemaRecognitionTests.cs
+++ b/physicalTests/OssSamples/DummyFlagSchemaRecognitionTests.cs
@@ -114,7 +114,7 @@ public class DummyFlagSchemaRecognitionTests
             await TestEnvironment.ResetAsync();
 
         }
-        catch (Exception ex)
+        catch (Exception)
         {
         }
 

--- a/physicalTests/OssSamples/SchemaNameCaseSensitivityTests.cs
+++ b/physicalTests/OssSamples/SchemaNameCaseSensitivityTests.cs
@@ -67,7 +67,7 @@ public class SchemaNameCaseSensitivityTests
             await TestEnvironment.ResetAsync();
 
         }
-        catch (Exception ex)
+        catch (Exception)
         {
         }
 

--- a/src/Messaging/Producers/KafkaProducerManager.cs
+++ b/src/Messaging/Producers/KafkaProducerManager.cs
@@ -147,7 +147,7 @@ internal class KafkaProducerManager : IDisposable
         var keyType = KeyExtractor.DetermineKeyType(model);
         var keySerializer = CreateKeySerializer(keyType);
 
-        var typedValueSerializer = new AsyncSchemaRegistrySerializer<T>(_schemaRegistryClient.Value, AutomaticRegistrationBehavior.Always).AsSyncOverAsync();
+        var typedValueSerializer = new AsyncSchemaRegistrySerializer<T>(_schemaRegistryClient.Value).AsSyncOverAsync();
 
         return new ProducerBuilder<object, T>(config)
             .SetKeySerializer(keySerializer)
@@ -294,7 +294,7 @@ internal class KafkaProducerManager : IDisposable
     {
         var schema = DynamicSchemaGenerator.GetSchema<T>();
         _logger?.LogDebug("Generated key schema: {Schema}", schema.ToString());
-        var typed = new AsyncSchemaRegistrySerializer<T>(_schemaRegistryClient.Value, AutomaticRegistrationBehavior.Always).AsSyncOverAsync();
+        var typed = new AsyncSchemaRegistrySerializer<T>(_schemaRegistryClient.Value).AsSyncOverAsync();
         return SerializerAdapters.ToObjectSerializer(typed);
     }
 
@@ -305,7 +305,7 @@ internal class KafkaProducerManager : IDisposable
             return cached;
         var schema = DynamicSchemaGenerator.GetSchema<T>();
         _logger?.LogDebug("Generated value schema: {Schema}", schema.ToString());
-        var typed = new AsyncSchemaRegistrySerializer<T>(_schemaRegistryClient.Value, AutomaticRegistrationBehavior.Always).AsSyncOverAsync();
+        var typed = new AsyncSchemaRegistrySerializer<T>(_schemaRegistryClient.Value).AsSyncOverAsync();
         var serializer = SerializerAdapters.ToObjectSerializer(typed);
         _valueSerializerCache[type] = serializer;
         return serializer;


### PR DESCRIPTION
## Summary
- stop automatic schema registration in `KafkaProducerManager`
- log this change in progress file

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj -c Release --filter "Category!=Integration"`

------
https://chatgpt.com/codex/tasks/task_e_6881fb21000483278e749ff95f94cc71