### PR TITLE
Fix integration test compose file path

### DIFF
--- a/docs/changes/20250724_progress.md
+++ b/docs/changes/20250724_progress.md
@@ -35,3 +35,5 @@
 ## 2025-07-24 18:39 JST [assistant]
 - Messaging層の自動スキーマ登録を削除
 
+## 2025-07-24 20:31 JST [assistant]
+- add docker-compose.kafka.yml to test output to prevent file not found errors

--- a/physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj
+++ b/physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj
@@ -18,5 +18,9 @@
     <None Update="docker-compose.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="../tools/docker-compose.kafka.yml">
+      <Link>tools/docker-compose.kafka.yml</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- copy tools/docker-compose.kafka.yml to integration test output
- add progress log entry for 2025-07-24

## Testing
- `dotnet test Kafka.Ksql.Linq.sln -c Debug -v minimal` *(fails: Kafka connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6882190dae4483279e71cb1612d0f018