### PR TITLE
Simplify DLQ integration test

### DIFF
--- a/docs/changes/20250724_progress.md
+++ b/docs/changes/20250724_progress.md
@@ -35,3 +35,5 @@
 ## 2025-07-24 18:39 JST [assistant]
 - Messaging層の自動スキーマ登録を削除
 
+## 2025-07-24 20:41 JST [assistant]
+- Simplified DlqIntegrationTests to use typed OnError().ForEachAsync chain without reflection


### PR DESCRIPTION
## Summary
- simplify DlqIntegrationTests to avoid reflection
- log progress

## Testing
- `dotnet test` *(fails: Schema Registry not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68821acb6ddc8327831506e18fe2d42b