### PR TITLE
Refactor TestEnvironment setup

### DIFF
--- a/docs/changes/20250724_progress.md
+++ b/docs/changes/20250724_progress.md
@@ -17,6 +17,9 @@
 ## 2025-07-24 12:52 JST [assistant]
 - Documented DLQ stream restrictions and enforced OnError(DLQ) ban
 
+## 2025-07-24 21:33 JST [assistant]
+- Refactored TestEnvironment.SetupAsync to execute ksqlDB statements via HTTP instead of KsqlContext.
+
 
 ## 2025-07-24 12:24 JST [assistant]
 - Added WaitForEntityReadyAsync API and sample usage


### PR DESCRIPTION
## Summary
- refactor TestEnvironment.SetupAsync to execute ksqlDB statements via HttpClient
- remove unused model namespace
- log progress about the change

## Testing
- `dotnet test physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj --filter Category=Integration` *(fails: IEntitySet<DlqIntegrationTests.Order> does not contain a definition for 'OnError')*

------
https://chatgpt.com/codex/tasks/task_e_688226dc54fc8327a2bbebc24f80c5de