### PR TITLE
Clarify test context

### DIFF
--- a/docs/changes/20250731_progress.md
+++ b/docs/changes/20250731_progress.md
@@ -137,3 +137,10 @@
 - improved schema setup retries and validation
 ## 2025-07-24 16:55 JST [sion]
 - updated GeneratedQuery_IsValidInKsqlDb to validate via raw HTTP client instead of AdminContext
+
+## 2025-07-24 12:44 JST [assistant]
+- removed AdminContext dependency from TestEnvironment and used lightweight BasicContext
+- TeardownAsync now drops tables and streams via HTTP statements
+
+## 2025-07-24 21:55 JST [assistant]
+- attempted to remove BasicContext per feedback but build fails since KsqlContext is abstract; keeping BasicContext


### PR DESCRIPTION
## Summary
- document why BasicContext subclass remains in tests
- noted attempt to remove BasicContext in progress log

## Testing
- `dotnet test` *(fails: KafkaRestProxyValidationTests.Appsettings_ShouldMapCorrectly_AndSendKafkaMessage)*

------
https://chatgpt.com/codex/tasks/task_e_688229b3be6083279fbf051f6d791d71