### PR TITLE
Preserve model builder flags when merging

### DIFF
--- a/src/KsqlContext.cs
+++ b/src/KsqlContext.cs
@@ -268,6 +268,11 @@ public abstract class KsqlContext : IKsqlContext
             if (_entityModels.TryGetValue(type, out var existing))
             {
                 existing.SetStreamTableType(model.GetExplicitStreamTableType());
+                existing.UseManualCommit = model.UseManualCommit;
+                existing.ErrorAction = model.ErrorAction;
+                existing.DeserializationErrorPolicy = model.DeserializationErrorPolicy;
+                existing.EnableCache = model.EnableCache;
+                existing.BarTimeSelector = model.BarTimeSelector;
             }
             else
             {

--- a/tests/ApplyModelBuilderSettingsTests.cs
+++ b/tests/ApplyModelBuilderSettingsTests.cs
@@ -1,0 +1,51 @@
+using Kafka.Ksql.Linq;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Modeling;
+using Kafka.Ksql.Linq.Configuration;
+using System;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests;
+
+public class ApplyModelBuilderSettingsTests
+{
+    private class Sample
+    {
+        public int Id { get; set; }
+        public DateTime Time { get; set; }
+    }
+
+    private class TestContext : KsqlContext
+    {
+        public TestContext() : base(new KsqlDslOptions()) { }
+        protected override bool SkipSchemaRegistration => true;
+
+        protected override void OnModelCreating(IModelBuilder modelBuilder)
+        {
+            // Auto-register by accessing the set before configuring
+            Set<Sample>();
+
+            var builder = (EntityModelBuilder<Sample>)modelBuilder.Entity<Sample>()
+                .AsTable(useCache: false)
+                .WithManualCommit();
+            builder.OnError(ErrorAction.DLQ);
+            var model = builder.GetModel();
+            model.DeserializationErrorPolicy = DeserializationErrorPolicy.DLQ;
+            model.BarTimeSelector = (Expression<Func<Sample, DateTime>>)(x => x.Time);
+        }
+    }
+
+    [Fact]
+    public void AutoRegisteredModel_PropertiesFromModelBuilderAreApplied()
+    {
+        var ctx = new TestContext();
+        var model = ctx.GetEntityModels()[typeof(Sample)];
+
+        Assert.True(model.UseManualCommit);
+        Assert.Equal(ErrorAction.DLQ, model.ErrorAction);
+        Assert.Equal(DeserializationErrorPolicy.DLQ, model.DeserializationErrorPolicy);
+        Assert.False(model.EnableCache);
+        Assert.NotNull(model.BarTimeSelector);
+    }
+}


### PR DESCRIPTION
## Summary
- copy additional properties when merging models during model building
- test that settings survive auto-registration prior to configuration

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj -v minimal --filter "Category!=Integration"`

------
https://chatgpt.com/codex/tasks/task_e_6882489010b48327a9a76492838b0022