### PR TITLE
Implement ConsumeWithContextAsync

### DIFF
--- a/src/Messaging/Consumers/KafkaConsumerManager.cs
+++ b/src/Messaging/Consumers/KafkaConsumerManager.cs
@@ -142,6 +142,22 @@ internal class KafkaConsumerManager : IDisposable
             yield return kafkaMessage.Value;
         }
     }
+
+    /// <summary>
+    /// KafkaストリームからT型データとKafkaMessageContextを非同期で取得する。
+    /// </summary>
+    public async IAsyncEnumerable<(T, KafkaMessageContext)> ConsumeWithContextAsync<T>(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
+    ) where T : class
+    {
+        var consumer = await GetConsumerAsync<T>();
+
+        await foreach (var kafkaMessage in consumer.ConsumeAsync(cancellationToken))
+        {
+            var ctx = kafkaMessage.Context ?? new KafkaMessageContext();
+            yield return (kafkaMessage.Value, ctx);
+        }
+    }
   
     /// <summary>
     /// エンティティ一覧取得 - EventSetから使用


### PR DESCRIPTION
## Summary
- extend `KafkaConsumerManager` with `ConsumeWithContextAsync` for streaming entities with message context

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj -v minimal` *(fails: 4 failed, 431 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6882e64a517083279c44df328ae5840d