### PR TITLE
Fix outdated test stubs

### DIFF
--- a/physicalTests/KsqlSyntax/DynamicKsqlGenerationTests.cs
+++ b/physicalTests/KsqlSyntax/DynamicKsqlGenerationTests.cs
@@ -2,6 +2,7 @@ using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Modeling;
 using Kafka.Ksql.Linq.Query.Pipeline;
 using Kafka.Ksql.Linq.Query.Abstractions;
+using Kafka.Ksql.Linq.Query.Ddl;
 using Kafka.Ksql.Linq.Application;
 using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Configuration;
@@ -58,10 +59,11 @@ public class DynamicKsqlGenerationTests
         foreach (var model in models.Values)
         {
             var name = model.TopicName ?? model.EntityType.Name.ToLowerInvariant();
+            var provider = new EntityModelDdlAdapter(model);
             if (model.StreamTableType == StreamTableType.Table)
-                yield return ExecuteInScope(() => ddl.GenerateCreateTable(name, name, model));
+                yield return ExecuteInScope(() => ddl.GenerateCreateTable(provider));
             else
-                yield return ExecuteInScope(() => ddl.GenerateCreateStream(name, name, model));
+                yield return ExecuteInScope(() => ddl.GenerateCreateStream(provider));
         }
 
         IQueryable<OrderValue> orders = new List<OrderValue>().AsQueryable();

--- a/tests/Core/Window/WindowAggregatedEntitySetTests.cs
+++ b/tests/Core/Window/WindowAggregatedEntitySetTests.cs
@@ -36,7 +36,7 @@ public class WindowAggregatedEntitySetTests
         public Task RemoveAsync(T entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<T>());
         public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.CompletedTask;
-        public Task ForEachAsync(Func<T, KafkaMessageContext, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task ForEachAsync(Func<T, KafkaMessage<T, object>, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public string GetTopicName() => _model.TopicName ?? typeof(T).Name.ToLowerInvariant();
         public EntityModel GetEntityModel() => _model;
         public IKsqlContext GetContext() => _context;

--- a/tests/Core/Window/WindowCollectionTests.cs
+++ b/tests/Core/Window/WindowCollectionTests.cs
@@ -36,7 +36,8 @@ public class WindowCollectionTests
         public Task RemoveAsync(T entity, CancellationToken cancellationToken = default) { Items.Remove(entity); return Task.CompletedTask; }
         public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<T>(Items));
         public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.WhenAll(Items.Select(action));
-        public Task ForEachAsync(Func<T, KafkaMessageContext, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.WhenAll(Items.Select(i => action(i, new KafkaMessageContext())));
+        public Task ForEachAsync(Func<T, KafkaMessage<T, object>, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default)
+            => Task.WhenAll(Items.Select(i => action(i, new KafkaMessage<T, object> { Value = i, Key = new object() } )));
         public string GetTopicName() => _model.TopicName ?? typeof(T).Name.ToLowerInvariant();
         public EntityModel GetEntityModel() => _model;
         public IKsqlContext GetContext() => _context;

--- a/tests/Core/Window/WindowedEntitySetTests.cs
+++ b/tests/Core/Window/WindowedEntitySetTests.cs
@@ -36,7 +36,8 @@ public class WindowedEntitySetTests
         public Task RemoveAsync(T entity, CancellationToken cancellationToken = default) { Items.Remove(entity); return Task.CompletedTask; }
         public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<T>(Items));
         public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.WhenAll(Items.Select(action));
-        public Task ForEachAsync(Func<T, KafkaMessageContext, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.WhenAll(Items.Select(i => action(i, new KafkaMessageContext())));
+        public Task ForEachAsync(Func<T, KafkaMessage<T, object>, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default)
+            => Task.WhenAll(Items.Select(i => action(i, new KafkaMessage<T, object> { Value = i, Key = new object() } )));
         public string GetTopicName() => _model.TopicName ?? typeof(T).Name.ToLowerInvariant();
         public EntityModel GetEntityModel() => _model;
         public IKsqlContext GetContext() => _context;

--- a/tests/EventSetLimitExtensionsTests.cs
+++ b/tests/EventSetLimitExtensionsTests.cs
@@ -50,7 +50,8 @@ public class EventSetLimitExtensionsTests
         public Task AddAsync(RateCandle entity, Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task<List<RateCandle>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(_items.ToList());
         public Task ForEachAsync(Func<RateCandle, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.WhenAll(_items.Select(action));
-        public Task ForEachAsync(Func<RateCandle, KafkaMessageContext, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.WhenAll(_items.Select(i => action(i, new KafkaMessageContext())));
+        public Task ForEachAsync(Func<RateCandle, KafkaMessage<RateCandle, object>, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default)
+            => Task.WhenAll(_items.Select(i => action(i, new KafkaMessage<RateCandle, object> { Value = i, Key = new object() } )));
         public string GetTopicName() => _model.TopicName!;
         public EntityModel GetEntityModel() => _model;
         public IKsqlContext GetContext() => new DummyContext();

--- a/tests/Extensions/ScheduleWindowBuilderTests.cs
+++ b/tests/Extensions/ScheduleWindowBuilderTests.cs
@@ -122,7 +122,8 @@ public class ScheduleWindowBuilderTests
         public Task RemoveAsync(T entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(_query.ToList());
         public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.WhenAll(_query.Select(action));
-        public Task ForEachAsync(Func<T, KafkaMessageContext, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.WhenAll(_query.Select(i => action(i, new KafkaMessageContext())));
+        public Task ForEachAsync(Func<T, KafkaMessage<T, object>, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default)
+            => Task.WhenAll(_query.Select(i => action(i, new KafkaMessage<T, object> { Value = i, Key = new object() } )));
         public string GetTopicName() => _model.TopicName ?? typeof(T).Name.ToLowerInvariant();
         public EntityModel GetEntityModel() => _model;
         public IKsqlContext GetContext() => _context;

--- a/tests/Extensions/WindowFilterExtensionsTests.cs
+++ b/tests/Extensions/WindowFilterExtensionsTests.cs
@@ -28,7 +28,8 @@ public class WindowFilterExtensionsTests
         public Task RemoveAsync(T entity, CancellationToken cancellationToken = default) { _items.Remove(entity); return Task.CompletedTask; }
         public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<T>(_items));
         public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.WhenAll(_items.Select(action));
-        public Task ForEachAsync(Func<T, KafkaMessageContext, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.WhenAll(_items.Select(i => action(i, new KafkaMessageContext())));
+        public Task ForEachAsync(Func<T, KafkaMessage<T, object>, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default)
+            => Task.WhenAll(_items.Select(i => action(i, new KafkaMessage<T, object> { Value = i, Key = new object() } )));
         public string GetTopicName() => _model.TopicName ?? typeof(T).Name.ToLowerInvariant();
         public EntityModel GetEntityModel() => _model;
         public IKsqlContext GetContext() => throw new NotImplementedException();

--- a/tests/FakeSchemaRegistryClient.cs
+++ b/tests/FakeSchemaRegistryClient.cs
@@ -1,6 +1,7 @@
 using Confluent.SchemaRegistry;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Kafka.Ksql.Linq.Tests;

--- a/tests/Infrastructure/Consumer/KafkaConsumerManagerTests.cs
+++ b/tests/Infrastructure/Consumer/KafkaConsumerManagerTests.cs
@@ -43,7 +43,7 @@ public class KafkaConsumerManagerTests
         }
         public IAsyncEnumerable<KafkaMessage<SampleEntity, object>> ConsumeAsync(CancellationToken cancellationToken = default) => _consume(cancellationToken);
         public Task<KafkaBatch<SampleEntity, object>> ConsumeBatchAsync(KafkaBatchOptions options, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task CommitAsync() => Task.CompletedTask;
+        public Task CommitAsync(TopicPartitionOffset offset) => Task.CompletedTask;
         public Task SeekAsync(TopicPartitionOffset offset) => Task.CompletedTask;
         public List<TopicPartition> GetAssignedPartitions() => new();
         public void Dispose() { }

--- a/tests/Query/HasQueryFromTests.cs
+++ b/tests/Query/HasQueryFromTests.cs
@@ -1,5 +1,6 @@
 using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.Core.Modeling;
+using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Application;
 using System.Linq;
 using Xunit;

--- a/tests/Query/JoinableEntitySetTests.cs
+++ b/tests/Query/JoinableEntitySetTests.cs
@@ -1,5 +1,5 @@
 using Kafka.Ksql.Linq.Core.Modeling;
-using Kafka.Ksql.Linq.Query.Linq;
+using Kafka.Ksql.Linq.Query;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Tests;
 using System;
@@ -31,7 +31,7 @@ public class JoinableEntitySetTests
         public Task RemoveAsync(T entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<T>());
         public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.CompletedTask;
-        public Task ForEachAsync(Func<T, KafkaMessageContext, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task ForEachAsync(Func<T, KafkaMessage<T, object>, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public string GetTopicName() => typeof(T).Name;
         public EntityModel GetEntityModel()
         {

--- a/tests/Query/Pipeline/DDLQueryGeneratorTests.cs
+++ b/tests/Query/Pipeline/DDLQueryGeneratorTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using Kafka.Ksql.Linq.Query.Pipeline;
 using Kafka.Ksql.Linq.Query.Ddl;
+using Kafka.Ksql.Linq.Core.Modeling;
 using Xunit;
 using System.IO;
 namespace Kafka.Ksql.Linq.Tests.Query.Pipeline;

--- a/tests/Query/TypedJoinResultEntitySetTests.cs
+++ b/tests/Query/TypedJoinResultEntitySetTests.cs
@@ -1,4 +1,4 @@
-using Kafka.Ksql.Linq.Query.Linq;
+using Kafka.Ksql.Linq.Query;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Tests;
 using System;
@@ -30,7 +30,7 @@ public class TypedJoinResultEntitySetTests
         public Task RemoveAsync(T entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<T>());
         public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.CompletedTask;
-        public Task ForEachAsync(Func<T, KafkaMessageContext, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task ForEachAsync(Func<T, KafkaMessage<T, object>, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public string GetTopicName() => typeof(T).Name;
         public EntityModel GetEntityModel() => new EntityModel { EntityType = typeof(T), TopicName = typeof(T).Name.ToLowerInvariant(), AllProperties = typeof(T).GetProperties(), KeyProperties = Array.Empty<System.Reflection.PropertyInfo>(), ValidationResult = new ValidationResult { IsValid = true } };
         public IKsqlContext GetContext() => _context;

--- a/tests/StubEntitySet.cs
+++ b/tests/StubEntitySet.cs
@@ -18,7 +18,7 @@ internal class StubEntitySet<T> : IEntitySet<T> where T : class
     public Task RemoveAsync(T entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
     public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<T>());
     public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.CompletedTask;
-    public Task ForEachAsync(Func<T, KafkaMessageContext, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    public Task ForEachAsync(Func<T, KafkaMessage<T, object>, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.CompletedTask;
     public string GetTopicName() => "stub";
     public EntityModel GetEntityModel() => new EntityModel { EntityType = typeof(T) };
     public IKsqlContext GetContext() => throw new NotImplementedException();


### PR DESCRIPTION
## Summary
- adapt DynamicKsqlGenerationTests to new DDL API
- update test stub classes to use `KafkaMessage<T,object>`
- fix missing usings and interface implementations

## Testing
- `dotnet build physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj`
- `dotnet test Kafka.Ksql.Linq.sln` *(fails: build errors)*

------
https://chatgpt.com/codex/tasks/task_e_6884e8da1e6c8327bb076ecb2f1dbe04