### PR TITLE
Fix HasQueryFrom tests and add join stubs

### DIFF
--- a/docs/changes/20250727_progress.md
+++ b/docs/changes/20250727_progress.md
@@ -14,3 +14,5 @@
 ## 2025-07-27 22:00 JST [naruse]
 - `AutomaticQueryFlowTests` の using に `System.Linq` を追加しコンパイルエラーを解消
 - 依然としてパッケージ未取得のためテスト実行は失敗
+## 2025-07-27 00:14 JST [jinto]
+- Reintroduced join entity set classes and added HasQueryFrom for IEntityBuilder.

--- a/src/Core/Modeling/EntityBuilderQueryExtensions.cs
+++ b/src/Core/Modeling/EntityBuilderQueryExtensions.cs
@@ -106,6 +106,21 @@ public static class EntityBuilderQueryExtensions
     }
 
     /// <summary>
+    /// IEntityBuilder<T> 用の HasQueryFrom 拡張メソッド
+    /// </summary>
+    public static EntityModelBuilder<TTarget> HasQueryFrom<TSource, TTarget>(
+        this IEntityBuilder<TTarget> builder,
+        Expression<Func<IQueryable<TSource>, IQueryable<TTarget>>> queryExpression)
+        where TTarget : class
+        where TSource : class
+    {
+        if (builder is not EntityModelBuilder<TTarget> concreteBuilder)
+            throw new ArgumentException("Builder must be EntityModelBuilder<TTarget>", nameof(builder));
+
+        return concreteBuilder.HasQueryFrom<TSource, TTarget>(queryExpression);
+    }
+
+    /// <summary>
     /// クエリビルダーを使用した詳細設定
     /// </summary>
     public static EntityModelBuilder<T> HasQuery<T>(

--- a/src/Query/Linq/JoinResult.cs
+++ b/src/Query/Linq/JoinResult.cs
@@ -1,0 +1,91 @@
+using Kafka.Ksql.Linq.Core.Abstractions;
+using System;
+using System.Linq.Expressions;
+
+namespace Kafka.Ksql.Linq.Query;
+
+internal class JoinResult<TOuter, TInner> : IJoinResult<TOuter, TInner>
+    where TOuter : class
+    where TInner : class
+{
+    private readonly IEntitySet<TOuter> _outer;
+    private readonly IEntitySet<TInner> _inner;
+    private readonly Expression<Func<TOuter, object>> _outerKeySelector;
+    private readonly Expression<Func<TInner, object>> _innerKeySelector;
+
+    public JoinResult(
+        IEntitySet<TOuter> outer,
+        IEntitySet<TInner> inner,
+        Expression outerKeySelector,
+        Expression innerKeySelector)
+    {
+        _outer = outer ?? throw new ArgumentNullException(nameof(outer));
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        _outerKeySelector = (Expression<Func<TOuter, object>>)outerKeySelector ?? throw new ArgumentNullException(nameof(outerKeySelector));
+        _innerKeySelector = (Expression<Func<TInner, object>>)innerKeySelector ?? throw new ArgumentNullException(nameof(innerKeySelector));
+    }
+
+    public IEntitySet<TResult> Select<TResult>(
+        Expression<Func<TOuter, TInner, TResult>> resultSelector) where TResult : class
+    {
+        if (resultSelector == null)
+            throw new ArgumentNullException(nameof(resultSelector));
+
+        return new TypedJoinResultEntitySet<TOuter, TInner, TResult>(
+               _outer.GetContext(),
+               CreateResultEntityModel<TResult>(),
+               _outer,
+               _inner,
+               _outerKeySelector,
+               _innerKeySelector,
+               resultSelector);
+    }
+
+    public IJoinResult<TOuter, TInner, TThird> Join<TThird, TKey>(
+        IEntitySet<TThird> third,
+        Expression<Func<TOuter, TKey>> outerKeySelector,
+        Expression<Func<TThird, TKey>> thirdKeySelector) where TThird : class
+    {
+        if (third == null)
+            throw new ArgumentNullException(nameof(third));
+        if (outerKeySelector == null)
+            throw new ArgumentNullException(nameof(outerKeySelector));
+        if (thirdKeySelector == null)
+            throw new ArgumentNullException(nameof(thirdKeySelector));
+
+        return new ThreeWayJoinResult<TOuter, TInner, TThird>(
+            _outer, _inner, third,
+            _outerKeySelector, _innerKeySelector,
+            outerKeySelector, thirdKeySelector);
+    }
+
+    public IJoinResult<TOuter, TInner, TThird> Join<TThird, TKey>(
+        IEntitySet<TThird> third,
+        Expression<Func<TInner, TKey>> innerKeySelector,
+        Expression<Func<TThird, TKey>> thirdKeySelector) where TThird : class
+    {
+        if (third == null)
+            throw new ArgumentNullException(nameof(third));
+        if (innerKeySelector == null)
+            throw new ArgumentNullException(nameof(innerKeySelector));
+        if (thirdKeySelector == null)
+            throw new ArgumentNullException(nameof(thirdKeySelector));
+
+        return new ThreeWayJoinResult<TOuter, TInner, TThird>(
+            _outer, _inner, third,
+            _outerKeySelector, _innerKeySelector,
+            innerKeySelector, thirdKeySelector);
+    }
+
+    private static EntityModel CreateResultEntityModel<TResult>() where TResult : class
+    {
+        return new EntityModel
+        {
+            EntityType = typeof(TResult),
+            TopicName = $"{typeof(TResult).Name.ToLowerInvariant()}_joinresult",
+            AllProperties = typeof(TResult).GetProperties(),
+            KeyProperties = Array.Empty<System.Reflection.PropertyInfo>(),
+            ValidationResult = new ValidationResult { IsValid = true }
+        };
+    }
+}

--- a/src/Query/Linq/JoinableEntitySet.cs
+++ b/src/Query/Linq/JoinableEntitySet.cs
@@ -1,0 +1,80 @@
+using Kafka.Ksql.Linq.Core.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kafka.Ksql.Linq.Query;
+
+/// <summary>
+/// JOIN 操作対応の EntitySet ラッパー
+/// </summary>
+public class JoinableEntitySet<T> : IEntitySet<T>, IJoinableEntitySet<T> where T : class
+{
+    private readonly IEntitySet<T> _baseEntitySet;
+
+    public JoinableEntitySet(IEntitySet<T> baseEntitySet)
+    {
+        _baseEntitySet = baseEntitySet ?? throw new ArgumentNullException(nameof(baseEntitySet));
+    }
+
+    public Task AddAsync(T entity, Dictionary<string,string>? headers = null, CancellationToken cancellationToken = default)
+    {
+        return _baseEntitySet.AddAsync(entity, headers, cancellationToken);
+    }
+
+    public Task RemoveAsync(T entity, CancellationToken cancellationToken = default)
+    {
+        return _baseEntitySet.RemoveAsync(entity, cancellationToken);
+    }
+
+    public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default)
+    {
+        return _baseEntitySet.ToListAsync(cancellationToken);
+    }
+
+    public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default)
+    {
+        return _baseEntitySet.ForEachAsync(action, timeout, cancellationToken);
+    }
+
+    public Task ForEachAsync(Func<T, KafkaMessage<T,object>, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default)
+    {
+        return _baseEntitySet.ForEachAsync(action, timeout, cancellationToken);
+    }
+
+    public string GetTopicName() => _baseEntitySet.GetTopicName();
+
+    public EntityModel GetEntityModel() => _baseEntitySet.GetEntityModel();
+
+    public IKsqlContext GetContext() => _baseEntitySet.GetContext();
+
+    public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+    {
+        await foreach (var item in _baseEntitySet.WithCancellation(cancellationToken))
+        {
+            yield return item;
+        }
+    }
+
+    public IJoinResult<T, TInner> Join<TInner, TKey>(
+        IEntitySet<TInner> inner,
+        Expression<Func<T, TKey>> outerKeySelector,
+        Expression<Func<TInner, TKey>> innerKeySelector) where TInner : class
+    {
+        if (inner == null)
+            throw new ArgumentNullException(nameof(inner));
+        if (outerKeySelector == null)
+            throw new ArgumentNullException(nameof(outerKeySelector));
+        if (innerKeySelector == null)
+            throw new ArgumentNullException(nameof(innerKeySelector));
+
+        return new JoinResult<T, TInner>(this, inner, outerKeySelector, innerKeySelector);
+    }
+
+    public override string ToString()
+    {
+        return $"JoinableEntitySet<{typeof(T).Name}> wrapping {_baseEntitySet}";
+    }
+}

--- a/src/Query/Linq/ThreeWayJoinResult.cs
+++ b/src/Query/Linq/ThreeWayJoinResult.cs
@@ -1,0 +1,68 @@
+using Kafka.Ksql.Linq.Core.Abstractions;
+using System;
+using System.Linq.Expressions;
+
+namespace Kafka.Ksql.Linq.Query;
+
+internal class ThreeWayJoinResult<TOuter, TInner, TThird> : IJoinResult<TOuter, TInner, TThird>
+    where TOuter : class
+    where TInner : class
+    where TThird : class
+{
+    private readonly IEntitySet<TOuter> _outer;
+    private readonly IEntitySet<TInner> _inner;
+    private readonly IEntitySet<TThird> _third;
+    private readonly Expression _outerKeySelector;
+    private readonly Expression _innerKeySelector;
+    private readonly Expression _firstThirdKeySelector;
+    private readonly Expression _secondThirdKeySelector;
+
+    public ThreeWayJoinResult(
+        IEntitySet<TOuter> outer,
+        IEntitySet<TInner> inner,
+        IEntitySet<TThird> third,
+        Expression outerKeySelector,
+        Expression innerKeySelector,
+        Expression firstThirdKeySelector,
+        Expression secondThirdKeySelector)
+    {
+        _outer = outer ?? throw new ArgumentNullException(nameof(outer));
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        _third = third ?? throw new ArgumentNullException(nameof(third));
+        _outerKeySelector = outerKeySelector ?? throw new ArgumentNullException(nameof(outerKeySelector));
+        _innerKeySelector = innerKeySelector ?? throw new ArgumentNullException(nameof(innerKeySelector));
+        _firstThirdKeySelector = firstThirdKeySelector ?? throw new ArgumentNullException(nameof(firstThirdKeySelector));
+        _secondThirdKeySelector = secondThirdKeySelector ?? throw new ArgumentNullException(nameof(secondThirdKeySelector));
+    }
+
+    public IEntitySet<TResult> Select<TResult>(
+        Expression<Func<TOuter, TInner, TThird, TResult>> resultSelector) where TResult : class
+    {
+        if (resultSelector == null)
+            throw new ArgumentNullException(nameof(resultSelector));
+
+        return new TypedThreeWayJoinResultEntitySet<TOuter, TInner, TThird, TResult>(
+                      _outer.GetContext(),
+                      CreateResultEntityModel<TResult>(),
+                      _outer,
+                      _inner,
+                      _third,
+                      _outerKeySelector,
+                      _innerKeySelector,
+                      _firstThirdKeySelector,
+                      _secondThirdKeySelector,
+                      resultSelector);
+    }
+
+    private static EntityModel CreateResultEntityModel<TResult>() where TResult : class
+    {
+        return new EntityModel
+        {
+            EntityType = typeof(TResult),
+            TopicName = $"{typeof(TResult).Name.ToLowerInvariant()}_threewayjoinresult",
+            AllProperties = typeof(TResult).GetProperties(),
+            KeyProperties = Array.Empty<System.Reflection.PropertyInfo>(),
+            ValidationResult = new ValidationResult { IsValid = true }
+        };
+    }
+}

--- a/src/Query/Linq/TypedJoinResultEntitySet.cs
+++ b/src/Query/Linq/TypedJoinResultEntitySet.cs
@@ -1,0 +1,80 @@
+using Kafka.Ksql.Linq.Core.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kafka.Ksql.Linq.Query;
+
+internal class TypedJoinResultEntitySet<TOuter, TInner, TResult> : IEntitySet<TResult>
+       where TOuter : class
+       where TInner : class
+       where TResult : class
+{
+    private readonly IKsqlContext _context;
+    private readonly EntityModel _entityModel;
+    private readonly IEntitySet<TOuter> _outerEntitySet;
+    private readonly IEntitySet<TInner> _innerEntitySet;
+    private readonly Expression<Func<TOuter, object>> _outerKeySelector;
+    private readonly Expression<Func<TInner, object>> _innerKeySelector;
+    private readonly Expression<Func<TOuter, TInner, TResult>> _resultSelector;
+
+    public TypedJoinResultEntitySet(
+        IKsqlContext context,
+        EntityModel entityModel,
+        IEntitySet<TOuter> outerEntitySet,
+        IEntitySet<TInner> innerEntitySet,
+        Expression<Func<TOuter, object>> outerKeySelector,
+        Expression<Func<TInner, object>> innerKeySelector,
+        Expression<Func<TOuter, TInner, TResult>> resultSelector)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _entityModel = entityModel ?? throw new ArgumentNullException(nameof(entityModel));
+        _outerEntitySet = outerEntitySet ?? throw new ArgumentNullException(nameof(outerEntitySet));
+        _innerEntitySet = innerEntitySet ?? throw new ArgumentNullException(nameof(innerEntitySet));
+        _outerKeySelector = outerKeySelector ?? throw new ArgumentNullException(nameof(outerKeySelector));
+        _innerKeySelector = innerKeySelector ?? throw new ArgumentNullException(nameof(innerKeySelector));
+        _resultSelector = resultSelector ?? throw new ArgumentNullException(nameof(resultSelector));
+    }
+
+    public async Task<List<TResult>> ToListAsync(CancellationToken cancellationToken = default)
+    {
+        // JOIN 処理の簡易実装
+        await Task.Delay(100, cancellationToken);
+        return new List<TResult>();
+    }
+
+    public Task AddAsync(TResult entity, Dictionary<string,string>? headers = null, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException("Cannot add entities to a join result set");
+    }
+
+    public Task RemoveAsync(TResult entity, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException("Cannot remove entities from a join result set");
+    }
+
+    public Task ForEachAsync(Func<TResult, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException("ForEachAsync not supported on join result sets");
+    }
+
+    public Task ForEachAsync(Func<TResult, KafkaMessage<TResult,object>, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException("ForEachAsync not supported on join result sets");
+    }
+
+    public string GetTopicName() => (_entityModel.TopicName ?? typeof(TResult).Name).ToLowerInvariant();
+    public EntityModel GetEntityModel() => _entityModel;
+    public IKsqlContext GetContext() => _context;
+
+    public async IAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+    {
+        var results = await ToListAsync(cancellationToken);
+        foreach (var item in results)
+        {
+            yield return item;
+        }
+    }
+}

--- a/src/Query/Linq/TypedThreeWayJoinResultEntitySet.cs
+++ b/src/Query/Linq/TypedThreeWayJoinResultEntitySet.cs
@@ -1,0 +1,89 @@
+using Kafka.Ksql.Linq.Core.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kafka.Ksql.Linq.Query;
+
+internal class TypedThreeWayJoinResultEntitySet<TOuter, TInner, TThird, TResult> : IEntitySet<TResult>
+    where TOuter : class
+    where TInner : class
+    where TThird : class
+    where TResult : class
+{
+    private readonly IKsqlContext _context;
+    private readonly EntityModel _entityModel;
+    private readonly IEntitySet<TOuter> _outerEntitySet;
+    private readonly IEntitySet<TInner> _innerEntitySet;
+    private readonly IEntitySet<TThird> _thirdEntitySet;
+    private readonly Expression _outerKeySelector;
+    private readonly Expression _innerKeySelector;
+    private readonly Expression _firstThirdKeySelector;
+    private readonly Expression _secondThirdKeySelector;
+    private readonly Expression<Func<TOuter, TInner, TThird, TResult>> _resultSelector;
+
+    public TypedThreeWayJoinResultEntitySet(
+        IKsqlContext context,
+        EntityModel entityModel,
+        IEntitySet<TOuter> outerEntitySet,
+        IEntitySet<TInner> innerEntitySet,
+        IEntitySet<TThird> thirdEntitySet,
+        Expression outerKeySelector,
+        Expression innerKeySelector,
+        Expression firstThirdKeySelector,
+        Expression secondThirdKeySelector,
+        Expression<Func<TOuter, TInner, TThird, TResult>> resultSelector)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _entityModel = entityModel ?? throw new ArgumentNullException(nameof(entityModel));
+        _outerEntitySet = outerEntitySet ?? throw new ArgumentNullException(nameof(outerEntitySet));
+        _innerEntitySet = innerEntitySet ?? throw new ArgumentNullException(nameof(innerEntitySet));
+        _thirdEntitySet = thirdEntitySet ?? throw new ArgumentNullException(nameof(thirdEntitySet));
+        _outerKeySelector = outerKeySelector ?? throw new ArgumentNullException(nameof(outerKeySelector));
+        _innerKeySelector = innerKeySelector ?? throw new ArgumentNullException(nameof(innerKeySelector));
+        _firstThirdKeySelector = firstThirdKeySelector ?? throw new ArgumentNullException(nameof(firstThirdKeySelector));
+        _secondThirdKeySelector = secondThirdKeySelector ?? throw new ArgumentNullException(nameof(secondThirdKeySelector));
+        _resultSelector = resultSelector ?? throw new ArgumentNullException(nameof(resultSelector));
+    }
+
+    public async Task<List<TResult>> ToListAsync(CancellationToken cancellationToken = default)
+    {
+        await Task.Delay(100, cancellationToken);
+        return new List<TResult>();
+    }
+
+    public Task AddAsync(TResult entity, Dictionary<string,string>? headers = null, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException("Cannot add entities to a three-way join result set");
+    }
+
+    public Task RemoveAsync(TResult entity, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException("Cannot remove entities from a three-way join result set");
+    }
+
+    public Task ForEachAsync(Func<TResult, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException("ForEachAsync not supported on three-way join result sets");
+    }
+
+    public Task ForEachAsync(Func<TResult, KafkaMessage<TResult,object>, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException("ForEachAsync not supported on three-way join result sets");
+    }
+
+    public string GetTopicName() => (_entityModel.TopicName ?? typeof(TResult).Name).ToLowerInvariant();
+    public EntityModel GetEntityModel() => _entityModel;
+    public IKsqlContext GetContext() => _context;
+
+    public async IAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+    {
+        var results = await ToListAsync(cancellationToken);
+        foreach (var item in results)
+        {
+            yield return item;
+        }
+    }
+}

--- a/tests/Query/HasQueryFromTests.cs
+++ b/tests/Query/HasQueryFromTests.cs
@@ -28,10 +28,11 @@ public class HasQueryFromTests
         protected override void OnModelCreating(IModelBuilder modelBuilder)
         {
             modelBuilder.Entity<ApiMessage>();
-            modelBuilder.Entity<CategoryCount>()
-                .HasQueryFrom<ApiMessage>(q =>
-                    q.GroupBy(m => m.Category)
-                     .Select(g => new CategoryCount { Key = g.Key, Count = g.Count() }));
+            var catBuilder = (EntityModelBuilder<CategoryCount>)modelBuilder.Entity<CategoryCount>();
+            EntityBuilderQueryExtensions.HasQueryFrom<ApiMessage, CategoryCount>(
+                catBuilder,
+                q => q.GroupBy(m => m.Category)
+                      .Select(g => new CategoryCount { Key = g.Key, Count = g.Count() }));
         }
     }
 


### PR DESCRIPTION
## Summary
- provide `HasQueryFrom` extension for `IEntityBuilder<T>`
- reintroduce simple join-related entity set classes
- adjust `HasQueryFromTests` to call extension explicitly
- log progress

## Testing
- `dotnet build`
- `dotnet test --no-build` *(fails: Test host process crashed)*

------
https://chatgpt.com/codex/tasks/task_e_6884ee17b3e083279826c59ad0f386c5