### PR TITLE
Limit joins to two tables

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -450,6 +450,7 @@ AIは、指摘内容・理由を自動で集約・要約し、「現場設計Pro
 - [2025-07-12 広夢レポート](Reportsx/hiromu/20250712_hiromu_report.md)
 - [2025-07-17 差分ログ](docs/diff_log/diff_remove_producer_error_dlq_20250717.md)
 - [2025-07-19 詩音レポート](Reportsx/shion/20250719_shion_report.md)
+- [2025-07-27 差分ログ](docs/diff_log/diff_join_limit_20250727.md)
 
 ## イレギュラー対応ルール
 

--- a/docs/changes/20250727_progress.md
+++ b/docs/changes/20250727_progress.md
@@ -16,3 +16,6 @@
 - 依然としてパッケージ未取得のためテスト実行は失敗
 ## 2025-07-27 00:14 JST [jinto]
 - Reintroduced join entity set classes and added HasQueryFrom for IEntityBuilder.
+## 2025-07-27 00:42 JST [assistant]
+- Set MaxJoinTables to 2 and updated dependent code and docs
+

--- a/docs/diff_log/diff_join_limit_20250727.md
+++ b/docs/diff_log/diff_join_limit_20250727.md
@@ -1,0 +1,17 @@
+# 差分履歴: join_limit
+
+🗕 2025年7月27日（JST）
+🧐 作業者: assistant
+
+## 差分タイトル
+JOIN制限を2テーブルに変更
+
+## 変更理由
+ストリーム処理で扱うJOIN数を最小限に抑えるため。
+
+## 追加・修正内容（反映先: oss_design_combined.md）
+- `JoinLimitationEnforcer.MaxJoinTables` を 3 から 2 に変更
+- 関連コメント、テスト、ドキュメントを更新
+
+## 参考文書
+- `docs/namespaces/query_namespace_doc.md`

--- a/docs/namespaces/query_namespace_doc.md
+++ b/docs/namespaces/query_namespace_doc.md
@@ -36,10 +36,10 @@ LINQ式をKSQLクエリに変換する責務を担うnamespace。責務分離設
 ##### 共通基盤
 - **BuilderBase**: Builder共通制約・バリデーション
 - **BuilderValidation**: 式木安全性チェック、深度制限
-- **JoinLimitationEnforcer**: 3テーブル制限の厳格実装
+- **JoinLimitationEnforcer**: 2テーブル制限の厳格実装
 
-#### ストリーム処理制約
-- 3テーブルJOIN制限
+-#### ストリーム処理制約
+- 2テーブルJOIN制限
 - ネストした集約関数禁止
 - 式木深度制限（スタックオーバーフロー防止）
 
@@ -87,7 +87,7 @@ JSON関数: JsonExtractString等
 - **GeneratorBase**: Generator共通制約、Builder依存注入必須
 - **DMLQueryGenerator**: SELECT文生成（Pull/Push Query対応）
 - **DDLQueryGenerator**: CREATE STREAM/TABLE文生成
-- **JoinQueryGenerator**: JOIN専門生成器（3テーブル制限対応）
+- **JoinQueryGenerator**: JOIN専門生成器（2テーブル制限対応）
 
 #### 構造化組み立て
 - **QueryStructure**: クエリ構造統一管理
@@ -101,7 +101,7 @@ JSON関数: JsonExtractString等
 #### JOIN操作サポート
 - **IJoinableEntitySet\<T>**: JOIN可能なEntitySet
 - **IJoinResult\<TOuter, TInner>**: 2テーブルJOIN結果
-- **IJoinResult\<TOuter, TInner, TThird>**: 3テーブルJOIN結果
+ - **IJoinResult\<TOuter, TInner, TThird>**: (旧仕様) 3テーブルJOIN結果
 - **JoinableEntitySet\<T>**: 既存EntitySetのJOIN機能拡張
 
 ## アーキテクチャ特徴
@@ -114,7 +114,7 @@ JSON関数: JsonExtractString等
 
 ### ストリーム処理対応
 - Pull Query（一回限り）vs Push Query（ストリーミング）
-- 3テーブルJOIN制限
+- 2テーブルJOIN制限
 - co-partitioningパフォーマンス考慮
 
 #### Push Query と Pull Query の対応
@@ -159,7 +159,7 @@ Core.Abstractions → Query.Abstractions ← Query.Builders
 
 1. **Builder依存注入必須**: Generatorは必ずBuilder注入
 2. **キーワード分離**: Builder=句内容、Generator=完全文
-3. **3テーブル制限**: ストリーム処理性能のための制限
+3. **2テーブル制限**: ストリーム処理性能のための制限
 4. **式木安全性**: 深度・複雑度制限によるスタックオーバーフロー防止
 5. **NULL安全**: 全Builder・Generatorで統一されたNULL処理
 

--- a/src/Query/Builders/Common/JoinLimitationEnforcer.cs
+++ b/src/Query/Builders/Common/JoinLimitationEnforcer.cs
@@ -8,11 +8,11 @@ namespace Kafka.Ksql.Linq.Query.Builders.Common;
 
 /// <summary>
 /// JOIN制限強制クラス
-/// 設計理由：ストリーム処理における3テーブル制限の厳格実装
+/// 設計理由：ストリーム処理における2テーブル制限の厳格実装
 /// </summary>
 internal static class JoinLimitationEnforcer
 {
-    public const int MaxJoinTables = 3;
+    public const int MaxJoinTables = 2;
 
     /// <summary>
     /// JOIN式の検証

--- a/src/Query/Builders/JoinExpressionVisitor.cs
+++ b/src/Query/Builders/JoinExpressionVisitor.cs
@@ -24,7 +24,7 @@ internal class JoinExpressionVisitor : ExpressionVisitor
                 var joinInfo = ProcessJoinCall(node);
                 _joins.Add(joinInfo);
 
-                // 3テーブル制限チェック
+                // 2テーブル制限チェック
                 if (_joins.Count > JoinLimitationEnforcer.MaxJoinTables - 1) // -1 because base table counts as 1
                 {
                     throw new InvalidOperationException(

--- a/tests/Query/Builders/JoinLimitationEnforcerTests.cs
+++ b/tests/Query/Builders/JoinLimitationEnforcerTests.cs
@@ -18,11 +18,9 @@ public class JoinLimitationEnforcerTests
         IQueryable<TestEntity> t1 = new List<TestEntity>().AsQueryable();
         IQueryable<ChildEntity> t2 = new List<ChildEntity>().AsQueryable();
         IQueryable<GrandChildEntity> t3 = new List<GrandChildEntity>().AsQueryable();
-        IQueryable<ExtraEntity> t4 = new List<ExtraEntity>().AsQueryable();
 
         var expr = t1.Join(t2, o => o.Id, i => i.ParentId, (o, i) => new { o, i })
                       .Join(t3, x => x.o.Id, g => g.ChildId, (x, g) => new { x.o, x.i, g })
-                      .Join(t4, x => x.o.Id, f => f.RefId, (x, f) => new { x.o, f })
                       .Expression;
 
         Assert.Throws<StreamProcessingException>(() => JoinLimitationEnforcer.ValidateJoinExpression(expr));


### PR DESCRIPTION
## Summary
- enforce a maximum of two tables in `JoinLimitationEnforcer`
- update join visitor checks to match
- revise namespace docs for the new join limit
- log the change in progress notes and diff_log
- add diff_log link to AGENTS.md

## Testing
- `dotnet test` *(fails: ksqlDB unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6884f5b5e1148327bc3dfbeae97ddbf2