### PR TITLE
Remove three-table join in JoinQueryGenerator

### DIFF
--- a/tests/Query/Pipeline/JoinQueryGeneratorTests.cs
+++ b/tests/Query/Pipeline/JoinQueryGeneratorTests.cs
@@ -31,31 +31,6 @@ public class JoinQueryGeneratorTests
         Assert.Contains("ON e.Id = c.ParentId", sql);
     }
 
-    [Fact]
-    public void GenerateThreeTableJoin_ReturnsJoinQuery()
-    {
-        Expression<Func<TestEntity, int>> k1 = e => e.Id;
-        Expression<Func<ChildEntity, int>> k2 = c => c.ParentId;
-        Expression<Func<ChildEntity, int>> k3 = c => c.Id;
-        Expression<Func<GrandChildEntity, int>> k4 = g => g.ChildId;
-
-        var generator = new JoinQueryGenerator();
-        var sql = generator.GenerateThreeTableJoin(
-            "TestEntity",
-            "ChildEntity",
-            "GrandChildEntity",
-            k1,
-            k2,
-            k3,
-            k4,
-            resultSelector: null,
-            isPullQuery: true);
-
-        Assert.Contains("JOIN ChildEntity", sql);
-        Assert.Contains("JOIN GrandChildEntity", sql);
-        Assert.Contains("ON t1.Id = t2.ParentId", sql);
-        Assert.Contains("ON t2.Id = t3.ChildId", sql);
-    }
 
     [Fact]
     public void GenerateLeftJoin_ReturnsLeftJoinQuery()


### PR DESCRIPTION
## Summary
- drop GenerateThreeTableJoin and BuildThreeTableJoinQuery
- focus JoinQueryGenerator on two-table and left joins
- adjust unit tests

## Testing
- `dotnet test Kafka.Ksql.Linq.sln` *(fails: Test host process crashed; failed to connect to Kafka)*

------
https://chatgpt.com/codex/tasks/task_e_6884fa1ba7448327b422e99f26ddc5a9