### PR TITLE
Update join limit tests

### DIFF
--- a/tests/Query/Builders/JoinClauseBuilderTests.cs
+++ b/tests/Query/Builders/JoinClauseBuilderTests.cs
@@ -10,10 +10,6 @@ namespace Kafka.Ksql.Linq.Tests.Query.Builders;
 
 public class JoinClauseBuilderTests
 {
-    private class FourthEntity
-    {
-        public int RefId { get; set; }
-    }
 
     [Fact]
     public void Build_InnerJoin_ReturnsJoinSql()
@@ -54,16 +50,14 @@ public class JoinClauseBuilderTests
     }
 
     [Fact]
-    public void Build_TooManyTables_Throws()
+    public void Build_JoinWithThirdTable_Throws()
     {
         IQueryable<TestEntity> t1 = new List<TestEntity>().AsQueryable();
         IQueryable<ChildEntity> t2 = new List<ChildEntity>().AsQueryable();
         IQueryable<GrandChildEntity> t3 = new List<GrandChildEntity>().AsQueryable();
-        IQueryable<FourthEntity> t4 = new List<FourthEntity>().AsQueryable();
 
         var join = Queryable.Join(t1, t2, o => o.Id, i => i.ParentId, (o, i) => new { o, i })
-                     .Join(t3, x => x.o.Id, g => g.ChildId, (x, g) => new { x.o, x.i, g })
-                     .Join(t4, x => x.o.Id, f => f.RefId, (x, f) => new { x.o, f });
+                     .Join(t3, x => x.o.Id, g => g.ChildId, (x, g) => new { x.o, x.i, g });
 
         var builder = new JoinClauseBuilder();
 

--- a/tests/Query/Pipeline/JoinQueryGeneratorTests.cs
+++ b/tests/Query/Pipeline/JoinQueryGeneratorTests.cs
@@ -50,4 +50,21 @@ public class JoinQueryGeneratorTests
         Assert.Contains("LEFT JOIN ChildEntity", sql);
         Assert.DoesNotContain("EMIT CHANGES", sql);
     }
+
+    [Fact]
+    public void GenerateFromLinqJoin_ThirdTable_Throws()
+    {
+        IQueryable<TestEntity> t1 = new List<TestEntity>().AsQueryable();
+        IQueryable<ChildEntity> t2 = new List<ChildEntity>().AsQueryable();
+        IQueryable<GrandChildEntity> t3 = new List<GrandChildEntity>().AsQueryable();
+
+        var expr = t1.Join(t2, o => o.Id, i => i.ParentId, (o, i) => new { o, i })
+                      .Join(t3, x => x.o.Id, g => g.ChildId, (x, g) => new { x.o, x.i, g })
+                      .Expression;
+
+        var generator = new JoinQueryGenerator();
+
+        var ex = Assert.Throws<InvalidOperationException>(() => generator.GenerateFromLinqJoin(expr));
+        Assert.Contains("maximum", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
 }


### PR DESCRIPTION
## Summary
- rewrite JoinClauseBuilder failing case
- add JoinQueryGenerator test covering a third-table join

## Testing
- `dotnet build --no-restore tests/Kafka.Ksql.Linq.Tests.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --no-build --verbosity minimal` *(fails: Assert.Equal failure and Kafka connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_6884fb9634048327bacb6d83af1e682c