### PR TITLE
Update join docs for query namespace

### DIFF
--- a/docs/changes/20250727_progress.md
+++ b/docs/changes/20250727_progress.md
@@ -19,3 +19,6 @@
 ## 2025-07-27 00:42 JST [assistant]
 - Set MaxJoinTables to 2 and updated dependent code and docs
 
+## 2025-07-27 01:17 JST [assistant]
+- Removed outdated 3-table join result description and confirmed 2-table join limit in documentation.
+

--- a/docs/diff_log/diff_query_namespace_doc_update_20250727.md
+++ b/docs/diff_log/diff_query_namespace_doc_update_20250727.md
@@ -1,0 +1,17 @@
+# 差分履歴: query_namespace_doc_update
+
+🗕 2025年7月27日（JST）
+🧐 作業者: assistant
+
+## 差分タイトル
+Query namespaceドキュメントのJOIN制限説明を更新
+
+## 変更理由
+JOIN制限が2テーブルに統一されたため、旧3テーブルJOIN関連記述を削除する。
+
+## 追加・修正内容（反映先: oss_design_combined.md）
+- `docs/namespaces/query_namespace_doc.md` から `IJoinResult<TOuter, TInner, TThird>` の説明を削除
+- 設計上の2テーブルJOIN制限を再確認
+
+## 参考文書
+- `docs/namespaces/query_namespace_doc.md`

--- a/docs/namespaces/query_namespace_doc.md
+++ b/docs/namespaces/query_namespace_doc.md
@@ -101,7 +101,6 @@ JSON関数: JsonExtractString等
 #### JOIN操作サポート
 - **IJoinableEntitySet\<T>**: JOIN可能なEntitySet
 - **IJoinResult\<TOuter, TInner>**: 2テーブルJOIN結果
- - **IJoinResult\<TOuter, TInner, TThird>**: (旧仕様) 3テーブルJOIN結果
 - **JoinableEntitySet\<T>**: 既存EntitySetのJOIN機能拡張
 
 ## アーキテクチャ特徴


### PR DESCRIPTION
## Summary
- clarify two-table join limit in Query namespace documentation
- remove old three-table join reference
- log changes and diff

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj -v minimal` *(fails: EventSetMapTests, ForEachAsyncStreamingTests, MappingRegistryTests, DlqStreamRestrictionsTests, DDLQueryGeneratorTests, KafkaRestProxyValidationTests)*

------
https://chatgpt.com/codex/tasks/task_e_6884fecb6d208327babb48a670cbcd6d